### PR TITLE
Add more button on diagnostic overlay

### DIFF
--- a/src/app/ApplicationTemplate.Shared/Presentation/Diagnostics/DiagnosticsOverlayViewModel.cs
+++ b/src/app/ApplicationTemplate.Shared/Presentation/Diagnostics/DiagnosticsOverlayViewModel.cs
@@ -35,6 +35,17 @@ namespace ApplicationTemplate
 			IsAlignmentGridEnabled = !IsAlignmentGridEnabled;
 		});
 
+		public bool IsDiagnosticsExpanded
+		{
+			get => this.Get<bool>();
+			set => this.Set(value);
+		}
+
+		public IDynamicCommand ToggleMore => this.GetCommand(() =>
+		{
+			IsDiagnosticsExpanded = !IsDiagnosticsExpanded;
+		});
+
 		public CountersData Counters => this.GetFromObservable(ObserveCounters, DiagnosticsCountersService.Counters);
 
 		private IObservable<CountersData> ObserveCounters =>

--- a/src/app/ApplicationTemplate.UWP/Views/Content/Diagnostics/DiagnosticsOverlay.xaml
+++ b/src/app/ApplicationTemplate.UWP/Views/Content/Diagnostics/DiagnosticsOverlay.xaml
@@ -3,6 +3,7 @@
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:uc="using:Nventive.View.Converters"
 			 xmlns:xamarin="http://nventive.com/xamarin"
 			 mc:Ignorable="d xamarin"
 			 d:DesignHeight="300"
@@ -19,7 +20,7 @@
 				<Setter Property="Margin"
 						Value="0,1" />
 				<Setter Property="TextAlignment"
-						Value="Right" />
+						Value="Center" />
 			</Style>
 
 			<Style x:Key="DiagnosticsCounterToolTipStyle"
@@ -29,12 +30,29 @@
 				<Setter Property="Foreground"
 						Value="WhiteSmoke" />
 			</Style>
+
+			<uc:FromNullableBoolToCustomValueConverter x:Key="TrueToHorizontalStretch"
+													   TrueValue="Stretch"
+													   NullOrFalseValue="Right" />
+
+			<uc:FromNullableBoolToCustomValueConverter x:Key="TrueToVerticalStretch"
+													   TrueValue="Stretch"
+													   NullOrFalseValue="Right" />
 		</ResourceDictionary>
 	</UserControl.Resources>
 
-	<StackPanel Background="#AA000000"
-				BorderThickness="1"
-				BorderBrush="#000000">
+	<Grid Background="#AA000000"
+		  BorderThickness="1"
+		  BorderBrush="#000000"
+		  HorizontalAlignment="{Binding IsDiagnosticsExpanded, Converter={StaticResource TrueToHorizontalStretch}, FallbackValue=Right}"
+		  VerticalAlignment="{Binding IsDiagnosticsExpanded, Converter={StaticResource TrueToVerticalStretch}, FallbackValue=Top}">
+
+		<Grid.RowDefinitions>
+			<RowDefinition Height="auto" />
+			<RowDefinition Height="auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
 		<StackPanel DataContext="{Binding Counters}"
 					Padding="4"
 					xamarin:IsHitTestVisible="False">
@@ -42,7 +60,7 @@
 			<TextBlock Foreground="#4cbfe1"
 					   Style="{StaticResource DiagnosticsCounterTextBlockStyle}">
 				<Run Text="AVM:" />
-				<Run Text="{Binding ActiveViewModels}" />					
+				<Run Text="{Binding ActiveViewModels}" />
 					
 				<ToolTipService.ToolTip>
 					<ToolTip Style="{StaticResource DiagnosticsCounterToolTipStyle}"
@@ -53,7 +71,7 @@
 			<TextBlock Foreground="#4cbfe1"
 					   Style="{StaticResource DiagnosticsCounterTextBlockStyle}">
 				<Run Text="UVM:" />
-				<Run Text="{Binding UncollectedViewModels}" />					
+				<Run Text="{Binding UncollectedViewModels}" />
 					
 				<ToolTipService.ToolTip>
 					<ToolTip Style="{StaticResource DiagnosticsCounterToolTipStyle}"
@@ -64,7 +82,7 @@
 			<TextBlock Foreground="#4cbfe1"
 					   Style="{StaticResource DiagnosticsCounterTextBlockStyle}">
 				<Run Text="AP:" />
-				<Run Text="{Binding ActiveProperties}" />					
+				<Run Text="{Binding ActiveProperties}" />
 					
 				<ToolTipService.ToolTip>
 					<ToolTip Style="{StaticResource DiagnosticsCounterToolTipStyle}"
@@ -75,7 +93,7 @@
 			<TextBlock Foreground="#4cbfe1"
 					   Style="{StaticResource DiagnosticsCounterTextBlockStyle}">
 				<Run Text="UP:" />
-				<Run Text="{Binding UncollectedProperties}" />					
+				<Run Text="{Binding UncollectedProperties}" />
 					
 				<ToolTipService.ToolTip>
 					<ToolTip Style="{StaticResource DiagnosticsCounterToolTipStyle}"
@@ -86,7 +104,7 @@
 			<TextBlock Foreground="#4cbfe1"
 					   Style="{StaticResource DiagnosticsCounterTextBlockStyle}">
 				<Run Text="AC:" />
-				<Run Text="{Binding ActiveCommands}" />					
+				<Run Text="{Binding ActiveCommands}" />
 					
 				<ToolTipService.ToolTip>
 					<ToolTip Style="{StaticResource DiagnosticsCounterToolTipStyle}"
@@ -97,7 +115,7 @@
 			<TextBlock Foreground="#4cbfe1"
 					   Style="{StaticResource DiagnosticsCounterTextBlockStyle}">
 				<Run Text="UC:" />
-				<Run Text="{Binding UncollectedCommands}" />					
+				<Run Text="{Binding UncollectedCommands}" />
 					
 				<ToolTipService.ToolTip>
 					<ToolTip Style="{StaticResource DiagnosticsCounterToolTipStyle}"
@@ -106,20 +124,43 @@
 			</TextBlock>
 		</StackPanel>
 
-		<Button Command="{Binding CollectMemory}"
-				Content="Collect"
-				HorizontalAlignment="Stretch"
-				Padding="4"
-				FontSize="12"
-				Foreground="White"
-				Background="#AA000000" />
+		<StackPanel Visibility="{Binding IsDiagnosticsExpanded, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
+					Grid.Row="1">
+			<!-- Diagnostics expanded content -->
+		</StackPanel>
 
-		<Button Command="{Binding ToggleAlignmentGrid}"
+		<StackPanel Grid.Row="2"
+					VerticalAlignment="Bottom">
+			<Button Command="{Binding CollectMemory}"
+					Content="Collect"
+					HorizontalAlignment="Stretch"
+					Padding="4"
+					FontSize="12"
+					Foreground="White"
+					Background="#AA000000" />
+			
+			<Button Command="{Binding ToggleAlignmentGrid}"
 				HorizontalAlignment="Stretch"
 				Content="Grid"
 				Padding="4"
 				FontSize="12"
 				Foreground="White"
 				Background="#AA000000" />
-	</StackPanel>
+
+			<Button Command="{Binding ToggleMore}"
+					HorizontalAlignment="Stretch"
+					Padding="4"
+					FontSize="12"
+					Foreground="White"
+					Background="#AA000000">
+				<Grid>
+					<TextBlock Text="More"
+							   Visibility="{Binding IsDiagnosticsExpanded, Converter={StaticResource TrueToCollapsed}, FallbackValue=Collapsed}" />
+
+					<TextBlock Text="Less"
+							   Visibility="{Binding IsDiagnosticsExpanded, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}" />
+				</Grid>
+			</Button>
+		</StackPanel>
+	</Grid>
 </UserControl>

--- a/src/app/ApplicationTemplate.UWP/Views/Shell.xaml
+++ b/src/app/ApplicationTemplate.UWP/Views/Shell.xaml
@@ -28,10 +28,8 @@
 
 		<local:DiagnosticsOverlay DataContext="{Binding DiagnosticsOverlay}"
 								  Visibility="{Binding IsDiagnosticsOverlayEnabled, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
-								  Margin="0,0,0,200"
-								  Grid.RowSpan="2"
-								  HorizontalAlignment="Right"
-								  VerticalAlignment="Bottom" />
+								  Margin="0,100"
+								  Grid.RowSpan="2" />
 
 		<splash:ExtendedSplashScreen x:Name="AppExtendedSplashScreen"
 									 ue:MultipleTapExtension.Command="{Binding DiagnosticsOverlay.NavigateToDiagnosticsPage}"


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?

- Feature

## Description

I've added a more button on the diagnostic overlay. This basically expand the diagnostic horizontally and vertically.

![Screenshot_20200616-171346](https://user-images.githubusercontent.com/17461593/84829429-c37fc380-aff5-11ea-9293-1ce663389ec4.png)

![Annotation 2020-06-17 085422](https://user-images.githubusercontent.com/17461593/84900705-7c86e200-b078-11ea-8b66-76067aaae392.jpg)

## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] ~~Interface members are XML documented~~
- [ ] ~~Documentation (XML or comments) has been added and/or existing documentation has been updated~~
- [ ] ~~[Architecture documents](./doc/Architecture.md) have been updated~~
- [x] Tested on all relevant platforms


## Other information

N/A
