### PR TITLE
Fix corestartup with //-:cnd:noEmit

### DIFF
--- a/src/app/ApplicationTemplate.Shared/CoreStartup.cs
+++ b/src/app/ApplicationTemplate.Shared/CoreStartup.cs
@@ -78,7 +78,9 @@ namespace ApplicationTemplate
 			{
 				await section.Navigate(ct, () => new OnboardingPageViewModel());
 			}
+			//-:cnd:noEmit
 #if __MOBILE__ || WINDOWS_UWP
+			//+:cnd:noEmit
 			var dispatcher = services.GetRequiredService<CoreDispatcher>();
 
 			_ = dispatcher.RunAsync(CoreDispatcherPriority.Normal, DismissSplashScreen);
@@ -87,7 +89,9 @@ namespace ApplicationTemplate
 			{
 				Shell.Instance.ExtendedSplashScreen.Dismiss();
 			}
+			//-:cnd:noEmit
 #endif
+			//+:cnd:noEmit
 		}
 
 		private void NotifyUserOnSessionExpired(IServiceProvider services)


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix


## Description

Surround #if statements with //-:cnd:noEmit and //-:cnd:noEmit.
This is related to [this comment](https://github.com/nventive/UnoApplicationTemplate/pull/14/files#r485917577).


## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] ~~Interface members are XML documented~~
- [ ] ~~Documentation (XML or comments) has been added and/or existing documentation has been updated~~
- [ ] ~~[Architecture documents](./doc/Architecture.md) have been updated~~
- [x] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->