### PR TITLE
fix: removed height setter on the NativeCommandBarPresenter

### DIFF
--- a/src/app/ApplicationTemplate.UWP/Views/Styles/Controls/CommandBar.xaml
+++ b/src/app/ApplicationTemplate.UWP/Views/Styles/Controls/CommandBar.xaml
@@ -71,7 +71,7 @@
 					<Border BorderBrush="{TemplateBinding Background}"
 							BorderThickness="{TemplateBinding Padding}"
 							Background="{TemplateBinding Background}">
-						<NativeCommandBarPresenter Height="100" />
+						<NativeCommandBarPresenter />
 					</Border>
 				</ControlTemplate>
 			</Setter.Value>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

-  iOS NavigationBar height is 44 and this should not be changed. When we set anything higher than that to a CommandBar we are "overflowing" the space iOS allows, causing the display of the command bar to be wrong.


## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [ ] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [x] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->