### PR TITLE
ci: adds cleanup steps for the release stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 * Support for Android 11 (March, 2021)
 
 ### Changed
+* Improved the build pipeline cleanup process
 
 ### Deprecated
 

--- a/build/stage-release-appcenter.yml
+++ b/build/stage-release-appcenter.yml
@@ -32,6 +32,13 @@ jobs:
             releaseNotesInput: |
               CI build
             isSilent: true
+        
+        - task: DeleteFiles@1
+          displayName: "Remove downloaded artifacts"
+          condition: always()
+          inputs:
+            SourceFolder: $(Pipeline.Workspace)
+            Contents: '**'
 
 - deployment: AppCenter_iOS
   pool: 
@@ -60,6 +67,13 @@ jobs:
             releaseNotesInput: |
               CI build            
             isSilent: true
+        
+        - task: DeleteFiles@1
+          displayName: "Remove downloaded artifacts"
+          condition: always()
+          inputs:
+            SourceFolder: $(Pipeline.Workspace)
+            Contents: '**'
 
 - deployment: AppCenter_Android
   pool: $(windowsPoolName)
@@ -94,14 +108,21 @@ jobs:
               keystorePassword: '$(AndroidSigningStorePass)'
               keystoreAlias: '$(AndroidSigningKeyAlias)'
               keystoreAliasPassword: '$(AndroidSigningKeyPass)'
-              outputFolder: '$(Build.SourcesDirectory)/tmp'
+              outputFolder: '$(Pipeline.Workspace)/tmp'
           
           - task: AppCenterDistribute@3
             displayName: Deploy Android to AppCenter
             inputs:
               serverEndpoint: $(AppCenterServiceConnection)
               appSlug: ${{ parameters.appCenterAndroidSlug }}
-              appFile: '$(Build.SourcesDirectory)/tmp/*.apk'
+              appFile: '$(Pipeline.Workspace)/tmp/*.apk'
               releaseNotesInput: |
                 CI build
               isSilent: true
+        
+          - task: DeleteFiles@1
+            displayName: "Remove downloaded artifacts"
+            condition: always()
+            inputs:
+              SourceFolder: $(Pipeline.Workspace)
+              Contents: '**'

--- a/build/stage-release-appstore.yml
+++ b/build/stage-release-appstore.yml
@@ -34,3 +34,10 @@ jobs:
             shouldSkipWaitingForProcessing: true
             teamId: $(AppleTeamId)
             teamName: $(AppleTeamName)
+        
+        - task: DeleteFiles@1
+          displayName: "Remove downloaded artifacts"
+          condition: always()
+          inputs:
+            SourceFolder: $(Pipeline.Workspace)
+            Contents: '**'

--- a/build/stage-release-googleplay.yml
+++ b/build/stage-release-googleplay.yml
@@ -28,3 +28,10 @@ jobs:
             bundleFile: '$(Pipeline.Workspace)/$(AndroidArtifactName)_${{ parameters.applicationEnvironment }}/*-Signed.aab'
             applicationId: '$(ApplicationIdentifier)'
             languageCode: 'en-CA'
+        
+        - task: DeleteFiles@1
+          displayName: "Remove downloaded artifacts"
+          condition: always()
+          inputs:
+            SourceFolder: $(Pipeline.Workspace)
+            Contents: '**'

--- a/build/stage-release-wasm.yml
+++ b/build/stage-release-wasm.yml
@@ -12,17 +12,19 @@ jobs:
     runOnce:
       deploy:
         steps:
-        - checkout: none
-
-        - task: DownloadBuildArtifacts@0
-          inputs:
-            buildType: current
-            downloadType: single
-            artifactName: $(WASMArtifactName)
+        - download: current
+          artifact: $(WASMArtifactName)
 
         - task: nventivecorp.nventive.nventive.websiteVersion.websiteVersion@5
           displayName: 'Publish to Azure'
           inputs:
-            WebsitePath: '$(System.ArtifactsDirectory)/$(WASMArtifactName)'
+            WebsitePath: '$(Pipeline.Workspace)/$(WASMArtifactName)'
             AzureSubscription: $(AzureSubscriptionName)
             AzureStorageAccount: $(AzureStorageAccountName)
+        
+        - task: DeleteFiles@1
+          displayName: "Remove downloaded artifacts"
+          condition: always()
+          inputs:
+            SourceFolder: $(Pipeline.Workspace)
+            Contents: '**'

--- a/build/steps-build-wasm.yml
+++ b/build/steps-build-wasm.yml
@@ -35,3 +35,7 @@
     PathtoPublish: $(build.artifactstagingdirectory)
     ArtifactName: $(ArtifactName)
     ArtifactType: Container
+
+- task: PostBuildCleanup@3
+  displayName: 'Post-Build cleanup :  Cleanup files to keep build server clean!'
+  condition: always()

--- a/doc/BuildPipeline.md
+++ b/doc/BuildPipeline.md
@@ -39,7 +39,9 @@ Because this is built on our internal machines, a cleanup step is also included 
 
 One thing to note here is that the build is also taking care of the signature of the application.
 
-#Release
+# Release
+
+The release stages are even more straigtforward than the build ones. One thing to note is that, for the same reason as it is done at the end of the build steps, a clean-up step is included in every stage.
 
 ## [stage-release-appcenter.yml](../build/stage-release-appcenter.yml)
 This stage is in charge of pushing the 3 versions of the application to AppCenter. Correspondingly, 3 jobs are run, one for each platform.


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?

- Build or CI related changes

## Description

Adds more cleanup steps to the pipeline. The release stages are now deleting the downloaded artifacts once they have been processed.


## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [x] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [ ] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->