### PR TITLE
Update System.Memory dependency to build on IOS vs VS 16.9.0+

### DIFF
--- a/src/app/ApplicationTemplate.iOS/ApplicationTemplate.iOS.csproj
+++ b/src/app/ApplicationTemplate.iOS/ApplicationTemplate.iOS.csproj
@@ -99,6 +99,9 @@
     <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.2" />
+    <PackageReference Include="System.Memory">
+      <Version>4.5.4</Version>
+    </PackageReference>
     <PackageReference Include="Uno.Microsoft.Toolkit.Uwp.DeveloperTools">
       <Version>6.1.0-build.205.g2e0e348372</Version>
     </PackageReference>


### PR DESCRIPTION
Fix output error with vs 16.9.0+ for IOS :
error CS1705: Assembly 'System.Text.Json' with identity 'System.Text.Json, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' uses 'System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' which has a higher version than referenced assembly 'System.Memory' with identity 'System.Memory, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'


GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

## Description

<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [ ] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [ ] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->