### PR TITLE
ci: Improves artifact cleanup

### DIFF
--- a/build/stage-release-appcenter.yml
+++ b/build/stage-release-appcenter.yml
@@ -11,6 +11,10 @@ jobs:
 - deployment: AppCenter_UWP
   pool: $(windowsPoolName)
 
+  variables:
+  - name: artifactName
+    value: $(UWPArtifactName)_${{ parameters.applicationEnvironment }}
+
   environment: ${{ parameters.deploymentEnvironment }}
 
   container: windows
@@ -21,14 +25,14 @@ jobs:
         steps:
 
         - download: current
-          artifact: $(UWPArtifactName)_${{ parameters.applicationEnvironment }}
+          artifact: $(artifactName)
 
         - task: AppCenterDistribute@3
           displayName: Deploy UWP to AppCenter
           inputs:
             serverEndpoint: $(AppCenterServiceConnection)
             appSlug: ${{ parameters.appCenterUWPSlug }}
-            appFile: $(Pipeline.Workspace)/$(UWPArtifactName)_${{ parameters.applicationEnvironment }}/*.msixbundle
+            appFile: $(Pipeline.Workspace)/$(artifactName)/*.msixbundle
             releaseNotesInput: |
               CI build
             isSilent: true
@@ -37,7 +41,8 @@ jobs:
           displayName: "Remove downloaded artifacts"
           condition: always()
           inputs:
-            SourceFolder: $(Pipeline.Workspace)
+            SourceFolder: $(Pipeline.Workspace)/$(artifactName)
+            RemoveSourceFolder: true
             Contents: '**'
 
 - deployment: AppCenter_iOS
@@ -45,6 +50,10 @@ jobs:
     name: $(macOSPoolName)
     demands:
     - fastlane
+
+  variables:
+  - name: artifactName
+    value: $(iOSArtifactName)_${{ parameters.applicationEnvironment }}
 
   environment: ${{ parameters.deploymentEnvironment }}
 
@@ -54,15 +63,15 @@ jobs:
         steps:
 
         - download: current
-          artifact: $(iOSArtifactName)_${{ parameters.applicationEnvironment }}
+          artifact: $(artifactName)
 
         - task: AppCenterDistribute@3
           displayName: Deploy iOS to AppCenter
           inputs:
             serverEndpoint: $(AppCenterServiceConnection)
             appSlug: ${{ parameters.appCenteriOSSlug }}
-            appFile: $(Pipeline.Workspace)/$(iOSArtifactName)_${{ parameters.applicationEnvironment }}/*.ipa
-            symbolsDsymFiles: $(Pipeline.Workspace)/$(iOSArtifactName)_${{ parameters.applicationEnvironment }}/*.dSYM
+            appFile: $(Pipeline.Workspace)/$(artifactName)/*.ipa
+            symbolsDsymFiles: $(Pipeline.Workspace)/$(artifactName)/*.dSYM
             symbolsIncludeParentDirectory: true
             releaseNotesInput: |
               CI build            
@@ -72,18 +81,20 @@ jobs:
           displayName: "Remove downloaded artifacts"
           condition: always()
           inputs:
-            SourceFolder: $(Pipeline.Workspace)
+            SourceFolder: $(Pipeline.Workspace)/$(artifactName)
+            RemoveSourceFolder: true
             Contents: '**'
 
 - deployment: AppCenter_Android
-  pool: $(windowsPoolName)
+  pool:
+    vmImage: windows-latest
 
   variables:
   - group: ${{ parameters.androidVariableGroup }}
+  - name: artifactName
+    value: $(AndroidArtifactName)_${{ parameters.applicationEnvironment }}  
     
   environment: ${{ parameters.deploymentEnvironment }}
-
-  container: windows
   
   strategy:
       runOnce:
@@ -91,7 +102,7 @@ jobs:
           steps:
           
           - download: current
-            artifact: $(AndroidArtifactName)_${{ parameters.applicationEnvironment }}
+            artifact: $(artifactName)
 
           - task: DownloadSecureFile@1
             name: keyStore
@@ -103,12 +114,12 @@ jobs:
 
           - task: AabConvertToUniversalApk@1
             inputs:
-              aabFilePath: '$(Pipeline.Workspace)/$(AndroidArtifactName)_${{ parameters.applicationEnvironment }}/*-Signed.aab'
+              aabFilePath: '$(Pipeline.Workspace)/$(artifactName)/*-Signed.aab'
               keystoreFilePath: '$(keyStore.secureFilePath)'
               keystorePassword: '$(AndroidSigningStorePass)'
               keystoreAlias: '$(AndroidSigningKeyAlias)'
               keystoreAliasPassword: '$(AndroidSigningKeyPass)'
-              outputFolder: '$(Pipeline.Workspace)/tmp'
+              outputFolder: '$(Pipeline.Workspace)/$(artifactName)/tmp'
           
           - task: AppCenterDistribute@3
             displayName: Deploy Android to AppCenter
@@ -124,5 +135,6 @@ jobs:
             displayName: "Remove downloaded artifacts"
             condition: always()
             inputs:
-              SourceFolder: $(Pipeline.Workspace)
+              SourceFolder: $(Pipeline.Workspace)/$(artifactName)
+              RemoveSourceFolder: true
               Contents: '**'

--- a/build/stage-release-appstore.yml
+++ b/build/stage-release-appstore.yml
@@ -14,6 +14,8 @@ jobs:
     
   variables:
   - group: ApplicationTemplate.Distribution.AppStore
+  - name: artifactName
+    value: $(iOSArtifactName)_${{ parameters.applicationEnvironment }}
 
   strategy:
     runOnce:
@@ -21,7 +23,7 @@ jobs:
         steps:
 
         - download: current
-          artifact: $(iOSArtifactName)_${{ parameters.applicationEnvironment }}
+          artifact: $(artifactName)
 
         - task: AppStoreRelease@1
           displayName: 'Publish to AppStore'
@@ -29,7 +31,7 @@ jobs:
             serviceEndpoint: $(AppStoreServiceConnection)
             appIdentifier: $(ApplicationIdentifier)
             appType: 'iOS'
-            ipaPath: '$(Pipeline.Workspace)/$(iOSArtifactName)_${{ parameters.applicationEnvironment }}/*.ipa'
+            ipaPath: '$(Pipeline.Workspace)/$(artifactName)/*.ipa'
             releaseTrack: 'TestFlight'
             shouldSkipWaitingForProcessing: true
             teamId: $(AppleTeamId)
@@ -39,5 +41,6 @@ jobs:
           displayName: "Remove downloaded artifacts"
           condition: always()
           inputs:
-            SourceFolder: $(Pipeline.Workspace)
+            SourceFolder: $(Pipeline.Workspace)/$(artifactName)
+            RemoveSourceFolder: True
             Contents: '**'

--- a/build/stage-release-googleplay.yml
+++ b/build/stage-release-googleplay.yml
@@ -12,6 +12,8 @@ jobs:
 
   variables:
   - group: ApplicationTemplate.Distribution.GooglePlay
+  - name: artifactName
+    value: $(AndroidArtifactName)_${{ parameters.applicationEnvironment }}
   
   strategy:
     runOnce:
@@ -19,13 +21,13 @@ jobs:
         steps:
 
         - download: current
-          artifact: $(AndroidArtifactName)_${{ parameters.applicationEnvironment }}
+          artifact: $(artifactName)
 
         - task: GooglePlayReleaseBundle@3
           displayName: 'Publish to GooglePlay'
           inputs:
             serviceConnection: $(GooglePlayServiceConnection)
-            bundleFile: '$(Pipeline.Workspace)/$(AndroidArtifactName)_${{ parameters.applicationEnvironment }}/*-Signed.aab'
+            bundleFile: '$(Pipeline.Workspace)/$(artifactName)/*-Signed.aab'
             applicationId: '$(ApplicationIdentifier)'
             languageCode: 'en-CA'
         
@@ -33,5 +35,6 @@ jobs:
           displayName: "Remove downloaded artifacts"
           condition: always()
           inputs:
-            SourceFolder: $(Pipeline.Workspace)
+            SourceFolder: $(Pipeline.Workspace)/$(artifactName)
+            RemoveSourceFolder: true
             Contents: '**'

--- a/build/stage-release-wasm.yml
+++ b/build/stage-release-wasm.yml
@@ -26,5 +26,6 @@ jobs:
           displayName: "Remove downloaded artifacts"
           condition: always()
           inputs:
-            SourceFolder: $(Pipeline.Workspace)
+            SourceFolder: $(Pipeline.Workspace)/$(WASMArtifactName)
+            RemoveSourceFolder: true
             Contents: '**'


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Build or CI related changes


## Description

This PR fixes the cleanup process after the release. The process currently tries to delete both the downloaded artifact and the source code folder if any, with the latter usually failing. The process has been adjusted to make sure only the downloaded artifact is being removed after the release.
<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [ ] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [ ] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->