### PR TITLE
ci: adds release notes generation

### DIFF
--- a/build/stage-release-appcenter.yml
+++ b/build/stage-release-appcenter.yml
@@ -33,8 +33,8 @@ jobs:
             serverEndpoint: $(AppCenterServiceConnection)
             appSlug: ${{ parameters.appCenterUWPSlug }}
             appFile: $(Pipeline.Workspace)/$(artifactName)/*.msixbundle
-            releaseNotesInput: |
-              CI build
+            releaseNotesOption: file
+            releaseNotesFile: $($(Pipeline.Workspace)/$(artifactName)/ReleaseNotes-Truncated.md
             isSilent: true
         
         - task: DeleteFiles@1
@@ -73,8 +73,8 @@ jobs:
             appFile: $(Pipeline.Workspace)/$(artifactName)/*.ipa
             symbolsDsymFiles: $(Pipeline.Workspace)/$(artifactName)/*.dSYM
             symbolsIncludeParentDirectory: true
-            releaseNotesInput: |
-              CI build            
+            releaseNotesOption: file
+            releaseNotesFile: $($(Pipeline.Workspace)/$(artifactName)/ReleaseNotes-Truncated.md
             isSilent: true
         
         - task: DeleteFiles@1
@@ -127,8 +127,8 @@ jobs:
               serverEndpoint: $(AppCenterServiceConnection)
               appSlug: ${{ parameters.appCenterAndroidSlug }}
               appFile: '$(Pipeline.Workspace)/$(artifactName)/*.apk'
-              releaseNotesInput: |
-                CI build
+              releaseNotesOption: file
+              releaseNotesFile: $($(Pipeline.Workspace)/$(artifactName)/ReleaseNotes-Truncated.md
               isSilent: true
         
           - task: DeleteFiles@1

--- a/build/steps-build.yml
+++ b/build/steps-build.yml
@@ -111,6 +111,16 @@ steps:
   inputs:
     codeCoverageTool: 'Cobertura'
     summaryFileLocation: "$(Build.SourcesDirectory)/src/coverage.cobertura.xml"
+  
+  # Generates basic release notes for App Center including: branch, commit id, url to the pipeline run, the environment name for the app
+- task: nventiveReleaseNotesCompiler@5
+  displayName: 'Generate release notes file'
+  inputs:
+    EnvironmentName: $(ApplicationEnvironment)
+    AdditionalReleaseNotesFile: Canary.md
+    OutputFilePath: $(Build.ArtifactStagingDirectory)/ReleaseNotes.md
+    CharacterLimit: 5000
+    TruncatedOutputFilePath: '$(Build.ArtifactStagingDirectory)/ReleaseNotes-Truncated.md'
 
 - publish: $(Build.ArtifactStagingDirectory)
   displayName: 'Publish artifact $(ApplicationConfiguration) | $(ApplicationPlatform)'


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Build or CI related changes


## Description

Adds the release notes generation step. This generates a simple markdown file with information about the commit, the branch, the build pipeline and the application environment.
This PR also includes a fix for the AppCenter release for Android.
<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [ ] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [ ] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->