### PR TITLE
feat(gitversion): Add support for main branch

### DIFF
--- a/gitversion.yml
+++ b/gitversion.yml
@@ -4,6 +4,7 @@ next-version: 1.0.0
 continuous-delivery-fallback-tag: ""
 branches:
   master:
+    regex: ^master$|^main$
     tag: dev
     increment: none
 ignore:


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Feature

## Description

- Add support for "main" branch as the new "master". It's the new default in AzureDevops repositories.
- This new version supports both "master" and "main".

## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [ ] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [ ] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->