### PR TITLE
ci : fix bundleidentifier and version replace fail for iOS - Android fix build number

### DIFF
--- a/build/steps-build.yml
+++ b/build/steps-build.yml
@@ -69,6 +69,24 @@ steps:
   inputs:
     provProfileSecureFile: ${{ parameters.iosProvisioningProfileFile }}
 
+# Since xamarin iOS 15, we need to bump the version prior to msbuild as it doesn't work through msbuild
+- task: UpdateiOSVersionInfoPlist@1
+  displayName: "Bump iOS version"
+  condition: and(succeeded(), not(eq('${{ parameters.iosProvisioningProfileFile }}', '')))
+  inputs:
+    infoPlistPath: $(InfoPlistPath)
+    bundleShortVersionString: '$(MajorMinorPatch)'
+    bundleVersion: '$(PreReleaseNumber)' 
+
+# Since xamarin iOS 15, bundle identifier needs to be changed prior to build task or it will fail as "mismatch bundle identifier"
+- task: ios-bundle-identifier@1
+  displayName: "Replace iOS bundle identifier"
+  condition: and(succeeded(), not(eq('${{ parameters.iosProvisioningProfileFile }}', '')))
+  inputs:
+    sourcePath: $(InfoPlistPath)
+    bundleIdentifier: $(ApplicationIdentifier)
+    printFile: true
+
 - task: MSBuild@1
   displayName: 'Build solution in $(ApplicationConfiguration) | $(ApplicationPlatform)'
   inputs:

--- a/build/steps-build.yml
+++ b/build/steps-build.yml
@@ -96,6 +96,7 @@ steps:
     msbuildArchitecture: x86
     msbuildArguments: >
       /p:PackageVersion=$(SemVer)
+      /p:ApplicationBuildNumber=$(PreReleaseNumber)
       /p:ApplicationEnvironment=$(ApplicationEnvironment)
       /p:ApplicationVersion=$(MajorMinorPatch)
       /p:AndroidSigningKeyStore=$(keyStore.secureFilePath)

--- a/build/variables.yml
+++ b/build/variables.yml
@@ -62,6 +62,9 @@ variables:
   # Solution to build
   SolutionFileName: ApplicationTemplate.sln
 
+  # Paths to file
+  InfoPlistPath: $(BuildSourceDirectory)/src/app/ApplicationTemplate.iOS/Info.plist
+
   # Pool names
   windowsPoolName: 'windows 1809'
   macOSPoolName: 'macOS'

--- a/build/variables.yml
+++ b/build/variables.yml
@@ -63,7 +63,7 @@ variables:
   SolutionFileName: ApplicationTemplate.sln
 
   # Paths to file
-  InfoPlistPath: $(BuildSourceDirectory)/src/app/ApplicationTemplate.iOS/Info.plist
+  InfoPlistPath: $(Build.SourcesDirectory)/src/app/ApplicationTemplate.iOS/Info.plist
 
   # Pool names
   windowsPoolName: 'windows 1809'


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?

**Bugfix** : 
- Fixing `ApplicationBundleIdentifier` , `BundleShortVersion`, `BundleVersion `not being replaced correctly in `Info.Plist` for iOS (the production stage is always failing due to this) 
- Fixing `BuildNumber` for Android always one step ahead of what's expected (it falls back to git count instead of relying on semver) 

## Description

Use specific tasks to replace `BundleIdentifier` and `Versions `, so the production stage stops failing. 

Use `ApplicationBuildNumber `msbuild argument to correctly set Build version for Android 

![image](https://user-images.githubusercontent.com/15191066/165337285-564e2d4d-cc47-4daa-8f54-d29c317ca892.png)

![image](https://user-images.githubusercontent.com/15191066/165337526-a15848f2-2ee0-4ef9-abcf-3457bbc11816.png)


<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [ ] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [ ] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->