### PR TITLE
ci: downgrade vs image for now to allow build to pass due to aot vs 2…

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -23,7 +23,7 @@ trigger:
 resources:
   containers:
     - container: windows
-      image: nventive/vs_build-tools:17.1.1
+      image: nventive/vs_build-tools:16.11.9
 
 variables:
 - template: build/variables.yml

--- a/build/variables.yml
+++ b/build/variables.yml
@@ -66,7 +66,7 @@ variables:
   InfoPlistPath: $(Build.SourcesDirectory)/src/app/ApplicationTemplate.iOS/Info.plist
 
   # Pool names
-  windowsPoolName: 'windows 2022'
+  windowsPoolName: 'windows 1809'
   macOSPoolName: 'macOS'
 
   # Versions to use


### PR DESCRIPTION
GitHub Issue: #

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Build or CI related changes

## Description

- Reverted to VS 2019 image tool while waiting for a fix with AOT profiling and VS 2022 issue 


## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [ ] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [ ] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->