### PR TITLE
chore: Split canary and regular pipeline into 2

### DIFF
--- a/.azure-pipelines-canary.yml
+++ b/.azure-pipelines-canary.yml
@@ -1,0 +1,45 @@
+trigger: # Start a new run as soon as a "canaries/build/(...)" branch is created.
+  branches:
+    include:
+      - canaries/build/*
+
+resources:
+  containers:
+    - container: windows
+      image: nventive/vs_build-tools:16.11.9
+      
+variables:
+- template: build/variables.yml
+
+# Build the project using the desired parameters (in this case same as staging), but update all nuget packages to latest.
+stages:
+- stage: Build_Canary
+  condition: and(ne(variables['IsLightBuild'], 'true'), eq(variables['IsCanary'], 'true'))
+  dependsOn: []
+  jobs:
+  - template: build/stage-build.yml
+    parameters:
+      applicationEnvironment: Staging
+      androidKeyStoreFile: $(InternalKeystore)
+      androidVariableGroup: 'ApplicationTemplate.Internal.Android'
+      iosProvisioningProfileFile: $(InternalProvisioningProfile)
+      iosCertificateFile: $(InternalCertificate)
+      iosVariableGroup: 'ApplicationTemplate.Internal.iOS'
+      removeHyperlinksFromReleaseNotes: true
+
+- stage: AppCenter_Canary
+  condition: and(succeeded(), eq(variables['IsCanary'], 'true'))
+  dependsOn: Build_Canary
+
+  jobs:
+  - template: build/stage-release-appcenter.yml
+    parameters:
+      applicationEnvironment: Staging
+      deploymentEnvironment: AppCenter
+      appCenterUWPSlug: $(AppCenterUWPSlug_Canary)
+      appCenteriOSSlug: $(AppCenteriOSSlug_Canary)
+      appCenterAndroidSlug: $(AppCenterAndroidSlug_Canary)
+      androidKeyStoreFile: $(InternalKeystore)
+      androidVariableGroup: 'ApplicationTemplate.Internal.Android'
+      appCenterServiceConnectionName: $(AppCenterCanaryServiceConnection)
+      appCenterDistributionGroup: $(AppCenterCanaryDistributionGroup)

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -6,6 +6,8 @@
 #   branches:
 #     include:
 #       - master
+#       - main
+#       - develop
 #       - release/*
 #       - feature/*
 pr:
@@ -30,7 +32,6 @@ variables:
 
 stages:
 - stage: Build_Staging
-  condition: eq(variables['IsCanary'], 'false')
   jobs:
   - template: build/stage-build.yml
     parameters:
@@ -54,21 +55,6 @@ stages:
       iosCertificateFile: $(AppStoreCertificate)
       iosVariableGroup: 'ApplicationTemplate.Distribution.AppStore'
 
-# Build steps for the Canary
-# Build the project the same as prod and QA builds, but update all nuget packages to latest
-- stage: Build_Canary
-  condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['IsCanary'], 'true'))
-  dependsOn: []
-  jobs:
-  - template: build/stage-build.yml
-    parameters:
-      applicationEnvironment: Staging
-      androidKeyStoreFile: $(InternalKeystore)
-      androidVariableGroup: 'ApplicationTemplate.Distribution.Internal.Android'
-      iosProvisioningProfileFile: $(InternalProvisioningProfile)
-      iosCertificateFile: $(InternalCertificate)
-      iosVariableGroup: 'ApplicationTemplate.Distribution.Internal.iOS'
-    
 - stage: AppCenter_Staging
   condition: and(succeeded(), eq(variables['IsLightBuild'], 'false'))
   dependsOn: Build_Staging
@@ -83,6 +69,8 @@ stages:
       appCenterAndroidSlug: $(AppCenterAndroidSlug)
       androidKeyStoreFile: $(InternalKeystore)
       androidVariableGroup: 'ApplicationTemplate.Distribution.Internal.Android'
+      appCenterServiceConnectionName: $(AppCenterServiceConnection)
+      appCenterDistributionGroup: $(AppCenterDistributionGroup)
 
 - stage: AppCenter_Production
   condition: and(succeeded(), eq(variables['IsLightBuild'], 'false'))
@@ -98,21 +86,8 @@ stages:
       appCenterAndroidSlug: $(AppCenterAndroidSlug_Production)
       androidKeyStoreFile: $(GooglePlayKeystore)
       androidVariableGroup: 'ApplicationTemplate.Distribution.GooglePlay'
-
-- stage: AppCenter_Canary
-  condition: and(succeeded(), eq(variables['IsCanary'], 'true'))
-  dependsOn: Build_Canary
-
-  jobs:
-  - template: build/stage-release-appcenter.yml
-    parameters:
-      applicationEnvironment: Staging
-      deploymentEnvironment: AppCenter
-      appCenterUWPSlug: $(AppCenterUWPSlug_Canary)
-      appCenteriOSSlug: $(AppCenteriOSSlug_Canary)
-      appCenterAndroidSlug: $(AppCenterAndroidSlug_Canary)
-      androidKeyStoreFile: $(InternalKeystore)
-      androidVariableGroup: 'ApplicationTemplate.Distribution.Internal.Android'
+      appCenterServiceConnectionName: $(AppCenterServiceConnection)
+      appCenterDistributionGroup: $(AppCenterDistributionGroup)
 
 - stage: AppStore
   condition: and(succeeded(), eq(variables['IsLightBuild'], 'false'))
@@ -120,7 +95,7 @@ stages:
 
   jobs:
   - template: build/stage-release-appstore.yml
-    parameters:    
+    parameters:
       applicationEnvironment: Production
       deploymentEnvironment: AppStore
 
@@ -130,6 +105,6 @@ stages:
 
   jobs:
   - template: build/stage-release-googleplay.yml
-    parameters:    
+    parameters:
       applicationEnvironment: Production
       deploymentEnvironment: GooglePlay

--- a/build/canary-merge.yml
+++ b/build/canary-merge.yml
@@ -1,8 +1,21 @@
+schedules:
+- cron: "00 05 * * Mon-Fri" # Format is "Minutes Hours DayOfMonth Month DayOfWeet" in UTC (that's why 05 is 1h EST)
+  displayName: 'Nightly weekdays build - 1:00 EST'
+  always: true # Start a new run even if the code didn't change (because packages might have changed).
+  branches:
+    include:
+      - canaries/dev
+
+trigger: # Start a new run as soon as canaries/dev changes.
+  branches:
+    include:
+      - canaries/dev
+
 pool:
   name: Windows 1809
 
 variables:
-- SolutionFileName: ApplicationTemplate.sln
+ SolutionFileName: ApplicationTemplate.sln
 
 steps:
 - checkout: self
@@ -33,9 +46,11 @@ steps:
     nugetVersion: 'dev,beta,stable'
     allowDowngrade: true
     packageAuthor: 'nventive'
+    ignorePackages: 'GeneratedSerializers.Json;Nventive.View.Uno;BiometryService'
     useVersionOverrides: true
     versionOverridesFile: 'https://raw.githubusercontent.com/nventive/Canary/master/version-overrides.json'
 
 - task: PostBuildCleanup@3
   displayName: 'Clean Agent Directories'
   condition: always()
+  

--- a/build/stage-build.yml
+++ b/build/stage-build.yml
@@ -17,8 +17,29 @@ parameters:
 - name: iosVariableGroup
   type: string
   default: ''
+- name: additionalReleaseNotesFile
+  type: string
+  default: 'Canary.md'
+- name: removeHyperlinksFromReleaseNotes
+  type: boolean
+  default: false
 
 jobs:
+  - job: On_Windows_ReleaseNotes
+    pool:
+      name: $(windowsPoolName)
+    variables:
+      ArtifactName: ReleaseNotes_${{ parameters.applicationEnvironment }}
+      ApplicationEnvironment: ${{ parameters.applicationEnvironment }}
+
+    container: windows
+
+    steps:
+      - template: steps-build-release-notes.yml
+        parameters:
+          additionalReleaseNotesFile: ${{ parameters.additionalReleaseNotesFile }}
+          removeHyperlinksFromReleaseNotes: ${{ parameters.removeHyperlinksFromReleaseNotes }}
+
   - job: On_Windows # Build UWP and Android on a windows machine
     strategy:
       maxParallel: 3
@@ -38,13 +59,13 @@ jobs:
           ApplicationPlatform: Any CPU
           ArtifactName: $(TestsArtifactName)_${{ parameters.applicationEnvironment }}
           ApplicationEnvironment: ${{ parameters.applicationEnvironment }}
-          
+
     pool:
       name: $(windowsPoolName)
 
     variables:
     - group: ${{ parameters.androidVariableGroup }}
-    
+
     container: windows
 
     steps:
@@ -60,12 +81,12 @@ jobs:
           ApplicationConfiguration: Release_iOS
           ApplicationPlatform: Any CPU
           ArtifactName: $(iOSArtifactName)_${{ parameters.applicationEnvironment }}
-          ApplicationEnvironment: ${{ parameters.applicationEnvironment }}   
+          ApplicationEnvironment: ${{ parameters.applicationEnvironment }}
     pool:
       name: $(macOSPoolName)
       demands:
         - Xamarin.iOS_Version -equals $(XAMARIN_IOS_VERSION)
-      
+
     variables:
     - name: SkipUnknownFrameworks
       value: true # Used by TargetFrameworks.Filtering package to build only what's possible on a mac for the multitargeted library

--- a/build/stage-release-appcenter.yml
+++ b/build/stage-release-appcenter.yml
@@ -3,9 +3,11 @@ parameters:
   deploymentEnvironment: '' # e.g. "GooglePlay", "AppStore", "AppCenter"
   appCenterUWPSlug: ''
   appCenteriOSSlug: ''
-  appCenterAndroidSlug: ''  
+  appCenterAndroidSlug: ''
   androidKeyStoreFile: ''
   androidVariableGroup: ''
+  appCenterServiceConnectionName: ''
+  appCenterDistributionGroup: ''
 
 jobs:
 - deployment: AppCenter_UWP
@@ -14,9 +16,13 @@ jobs:
   variables:
   - name: artifactName
     value: $(UWPArtifactName)_${{ parameters.applicationEnvironment }}
+  - name: releaseNotesArtifactName
+    value: ReleaseNotes_${{ parameters.applicationEnvironment }}
 
   environment: ${{ parameters.deploymentEnvironment }}
-  
+
+  container: windows
+
   strategy:
     runOnce:
       deploy:
@@ -24,31 +30,47 @@ jobs:
 
         - download: current
           artifact: $(artifactName)
+
+        - download: current
+          artifact: $(releaseNotesArtifactName)
 
         - task: AppCenterDistribute@3
           displayName: Deploy UWP to AppCenter
           inputs:
-            serverEndpoint: $(AppCenterServiceConnection)
+            serverEndpoint: ${{ parameters.appCenterServiceConnectionName }}
             appSlug: ${{ parameters.appCenterUWPSlug }}
             appFile: $(Pipeline.Workspace)/$(artifactName)/*.msixbundle
             releaseNotesOption: file
-            releaseNotesFile: $(Pipeline.Workspace)/$(artifactName)/ReleaseNotes-Truncated.md
+            releaseNotesFile: "$(Pipeline.Workspace)/$(releaseNotesArtifactName)/ReleaseNotes-Excerpt.md"
             isSilent: true
-        
+
         - task: DeleteFiles@1
-          displayName: "Remove downloaded artifacts"
+          displayName: "Remove downloaded artifacts (build)"
           condition: always()
           inputs:
             SourceFolder: $(Pipeline.Workspace)/$(artifactName)
             RemoveSourceFolder: true
             Contents: '**'
 
+        - task: DeleteFiles@1
+          displayName: "Remove downloaded artifacts (release notes)"
+          condition: always()
+          inputs:
+            SourceFolder: $(Pipeline.Workspace)/$(releaseNotesArtifactName)
+            RemoveSourceFolder: true
+            Contents: '**'
+
 - deployment: AppCenter_iOS
-  pool: $(macOSPoolName)
+  pool:
+    name: $(macOSPoolName)
+    demands:
+    - fastlane
 
   variables:
   - name: artifactName
     value: $(iOSArtifactName)_${{ parameters.applicationEnvironment }}
+  - name: releaseNotesArtifactName
+    value: ReleaseNotes_${{ parameters.applicationEnvironment }}
 
   environment: ${{ parameters.deploymentEnvironment }}
 
@@ -60,45 +82,61 @@ jobs:
         - download: current
           artifact: $(artifactName)
 
+        - download: current
+          artifact: $(releaseNotesArtifactName)
+
         - task: AppCenterDistribute@3
           displayName: Deploy iOS to AppCenter
           inputs:
-            serverEndpoint: $(AppCenterServiceConnection)
+            serverEndpoint: ${{ parameters.appCenterServiceConnectionName }}
             appSlug: ${{ parameters.appCenteriOSSlug }}
             appFile: $(Pipeline.Workspace)/$(artifactName)/*.ipa
             symbolsDsymFiles: $(Pipeline.Workspace)/$(artifactName)/*.dSYM
             symbolsIncludeParentDirectory: true
+            distributionGroupId: ${{ parameters.appCenterDistributionGroup }}
             releaseNotesOption: file
-            releaseNotesFile: $(Pipeline.Workspace)/$(artifactName)/ReleaseNotes-Truncated.md
+            releaseNotesFile: "$(Pipeline.Workspace)/$(releaseNotesArtifactName)/ReleaseNotes-Excerpt.md"
             isSilent: true
-        
+
         - task: DeleteFiles@1
-          displayName: "Remove downloaded artifacts"
+          displayName: "Remove downloaded artifacts (build)"
           condition: always()
           inputs:
             SourceFolder: $(Pipeline.Workspace)/$(artifactName)
             RemoveSourceFolder: true
             Contents: '**'
 
+        - task: DeleteFiles@1
+          displayName: "Remove downloaded artifacts (release notes)"
+          condition: always()
+          inputs:
+            SourceFolder: $(Pipeline.Workspace)/$(releaseNotesArtifactName)
+            RemoveSourceFolder: true
+            Contents: '**'
+
 - deployment: AppCenter_Android
-  # AabConvertToUniversalApk requires unzip, which is available on the Microsoft-hosted image
   pool:
-    image: windows-latest
-    
+    vmImage: windows-latest
+
   variables:
   - group: ${{ parameters.androidVariableGroup }}
   - name: artifactName
-    value: $(AndroidArtifactName)_${{ parameters.applicationEnvironment }}  
-    
+    value: $(AndroidArtifactName)_${{ parameters.applicationEnvironment }}
+  - name: releaseNotesArtifactName
+    value: ReleaseNotes_${{ parameters.applicationEnvironment }}
+
   environment: ${{ parameters.deploymentEnvironment }}
-  
+
   strategy:
       runOnce:
         deploy:
           steps:
-          
+
           - download: current
             artifact: $(artifactName)
+
+          - download: current
+            artifact: $(releaseNotesArtifactName)
 
           - task: DownloadSecureFile@1
             name: keyStore
@@ -116,21 +154,30 @@ jobs:
               keystoreAlias: '$(AndroidSigningKeyAlias)'
               keystoreAliasPassword: '$(AndroidSigningKeyPass)'
               outputFolder: '$(Pipeline.Workspace)/$(artifactName)'
-          
+
           - task: AppCenterDistribute@3
             displayName: Deploy Android to AppCenter
             inputs:
-              serverEndpoint: $(AppCenterServiceConnection)
+              serverEndpoint: ${{ parameters.appCenterServiceConnectionName }}
+              distributionGroupId: ${{ parameters.appCenterDistributionGroup }}
               appSlug: ${{ parameters.appCenterAndroidSlug }}
               appFile: '$(Pipeline.Workspace)/$(artifactName)/*.apk'
               releaseNotesOption: file
-              releaseNotesFile: $(Pipeline.Workspace)/$(artifactName)/ReleaseNotes-Truncated.md
+              releaseNotesFile: "$(Pipeline.Workspace)/$(releaseNotesArtifactName)/ReleaseNotes-Excerpt.md"
               isSilent: true
-        
+
           - task: DeleteFiles@1
-            displayName: "Remove downloaded artifacts"
+            displayName: "Remove downloaded artifacts (build)"
             condition: always()
             inputs:
               SourceFolder: $(Pipeline.Workspace)/$(artifactName)
+              RemoveSourceFolder: true
+              Contents: '**'
+          
+          - task: DeleteFiles@1
+            displayName: "Remove downloaded artifacts (release notes)"
+            condition: always()
+            inputs:
+              SourceFolder: $(Pipeline.Workspace)/$(releaseNotesArtifactName)
               RemoveSourceFolder: true
               Contents: '**'

--- a/build/stage-release-appstore.yml
+++ b/build/stage-release-appstore.yml
@@ -2,7 +2,7 @@
   applicationEnvironment: '' # e.g. "Staging", "Production"
   deploymentEnvironment: '' # e.g. "GooglePlay", "AppStore", "AppCenter"
 
-jobs: 
+jobs:
 - deployment: AppStore_iOS
 
   pool:
@@ -11,7 +11,7 @@ jobs:
       - Xamarin.iOS_Version -equals $(XAMARIN_IOS_VERSION)
 
   environment: ${{ parameters.deploymentEnvironment }}
-    
+
   variables:
   - group: ApplicationTemplate.Distribution.AppStore
   - name: artifactName
@@ -36,7 +36,7 @@ jobs:
             shouldSkipWaitingForProcessing: true
             teamId: $(AppleTeamId)
             teamName: $(AppleTeamName)
-        
+
         - task: DeleteFiles@1
           displayName: "Remove downloaded artifacts"
           condition: always()

--- a/build/stage-release-googleplay.yml
+++ b/build/stage-release-googleplay.yml
@@ -14,7 +14,7 @@ jobs:
   - group: ApplicationTemplate.Distribution.GooglePlay
   - name: artifactName
     value: $(AndroidArtifactName)_${{ parameters.applicationEnvironment }}
-  
+
   strategy:
     runOnce:
       deploy:
@@ -26,12 +26,12 @@ jobs:
         - task: GooglePlayRelease@4
           displayName: 'Release aab'
           inputs:
-            serviceEndpoint: '$(GooglePlayServiceConnection)'
+            serviceConnection: $(GooglePlayServiceConnection)
             applicationId: '$(ApplicationIdentifier)'
             action: 'SingleBundle'
             bundleFile: '$(Pipeline.Workspace)/$(artifactName)/*-Signed.aab'
             track: 'internal'
-        
+
         - task: DeleteFiles@1
           displayName: "Remove downloaded artifacts"
           condition: always()

--- a/build/steps-build-release-notes.yml
+++ b/build/steps-build-release-notes.yml
@@ -1,0 +1,26 @@
+parameters:
+- name: additionalReleaseNotesFile
+  type: string
+  default: 'Canary.md'
+- name: removeHyperlinksFromReleaseNotes
+  type: boolean
+  default: false
+
+steps:
+- powershell: New-Item -Path '$(ArtifactName)' -ItemType Directory
+  displayName: Create ReleaseNotes folder
+
+- task: nventiveReleaseNotesCompiler@5
+  displayName: 'Compile Release Notes'
+  inputs:
+    EnvironmentName: $(ApplicationEnvironment)
+    AdditionalReleaseNotesFile: ${{ parameters.additionalReleaseNotesFile }}
+    OutputFilePath: '$(ArtifactName)/ReleaseNotes.md'
+    CreateTruncatedVersion: true
+    TruncatedOutputFilePath: '$(ArtifactName)/ReleaseNotes-Excerpt.md'
+    CharacterLimit: 5000
+    RemoveHyperlinks: ${{ parameters.removeHyperlinksFromReleaseNotes }}
+
+- publish: $(ArtifactName)
+  displayName: 'Publish Release Notes'
+  artifact: $(ArtifactName)

--- a/build/steps-build.yml
+++ b/build/steps-build.yml
@@ -1,4 +1,4 @@
-﻿parameters:
+parameters:
 - name: androidKeyStoreFile
   type: string
   default: ''
@@ -95,7 +95,7 @@ steps:
     msbuildVersion: latest
     msbuildArchitecture: x86
     msbuildArguments: >
-      /p:PackageVersion=$(SemVer)
+      /p:PackageVersion=$(PreReleaseNumber)
       /p:ApplicationBuildNumber=$(PreReleaseNumber)
       /p:ApplicationEnvironment=$(ApplicationEnvironment)
       /p:ApplicationVersion=$(MajorMinorPatch)
@@ -131,17 +131,6 @@ steps:
   inputs:
     codeCoverageTool: 'Cobertura'
     summaryFileLocation: "$(Build.SourcesDirectory)/src/coverage.cobertura.xml"
-  
-  # Generates basic release notes for App Center including: branch, commit id, url to the pipeline run, the environment name for the app
-- task: nventiveReleaseNotesCompiler@5
-  displayName: 'Generate release notes file'
-  inputs:
-    EnvironmentName: $(ApplicationEnvironment)
-    AdditionalReleaseNotesFile: Canary.md
-    OutputFilePath: $(Build.ArtifactStagingDirectory)/ReleaseNotes.md
-    CreateTruncatedVersion: true
-    CharacterLimit: 5000
-    TruncatedOutputFilePath: '$(Build.ArtifactStagingDirectory)/ReleaseNotes-Truncated.md'
 
 - publish: $(Build.ArtifactStagingDirectory)
   displayName: 'Publish artifact $(ApplicationConfiguration) | $(ApplicationPlatform)'

--- a/build/variables.yml
+++ b/build/variables.yml
@@ -41,6 +41,7 @@ variables:
   GooglePlayServiceConnection: GooglePlay-nventive-ApplicationTemplate
   AppCenterServiceConnection: AppCenter-nventive-framework
   AppStoreServiceConnection: AppStore-nventive
+  AppCenterCanaryServiceConnection: AppCenter-nventive-framework
 
   # AppCenter slugs
   # The "app slug" corresponds to the identifiers of the app in AppCenter; to find it, navigate to the app in a browser and;
@@ -54,6 +55,10 @@ variables:
   AppCenterAndroidSlug_Canary: 'nventive-framework/Application-Template-Canary-1'
   AppCenteriOSSlug_Canary: 'nventive-framework/Application-Template-Canary'
   AppCenterUWPSlug_Canary: 'nventive-framework/Application-Template-Canary-2'
+
+  # AppCenter Distribution Groups
+  AppCenterDistributionGroup: '00000000-0000-0000-0000-000000000000'
+  AppCenterCanaryDistributionGroup: '00000000-0000-0000-0000-000000000000'
 
   # Azure subscription
   # AzureSubscriptionName:


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Build or CI related changes

## Description

<!-- (Please describe the changes that this PR introduces.) -->
- Update yml structure.
  - Remove canary build from regular pipeline.
  - Create separate yml for the canary pipeline.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [x] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [ ] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->