### PR TITLE
feat: Add dotnet new CI validation

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -26,12 +26,40 @@ resources:
   containers:
     - container: windows
       image: nventive/vs_build-tools:16.11.9
+#-if false
+    - container: windowsNet6 # .Net 6 is required for the dotnet new to work properly because of this bug: https://github.com/dotnet/templating/pull/2939
+      image: nventive/vs_build-tools:17.1.1
+#-endif
 
 variables:
 - template: build/variables.yml
 
 stages:
+#-if false
+# This special if is used to remove those Dotnet_New stages for generated apps.
+- stage: Dotnet_New_GeneratedApp
+  jobs:
+  - template: build/stage-donetnew.yaml
+
+- stage: Build_Staging_GeneratedApp
+  dependsOn: Dotnet_New_GeneratedApp
+  jobs:
+  - template: build/stage-build.yml
+    parameters:
+      pathToSrc: '$(Pipeline.Workspace)/GeneratedApp/src'
+      solutionFileName: 'GeneratedApp.sln'
+      pathToInfoPlist: '$(Pipeline.Workspace)/GeneratedApp/src/app/GeneratedApp.iOS/Info.plist'
+      applicationEnvironment: Generated_Staging
+      androidKeyStoreFile: $(InternalKeystore)
+      androidVariableGroup: 'ApplicationTemplate.Distribution.Internal.Android'
+      iosProvisioningProfileFile: $(InternalProvisioningProfile)
+      iosCertificateFile: $(InternalCertificate)
+      iosVariableGroup: 'ApplicationTemplate.Distribution.Internal.iOS'
+#-endif
 - stage: Build_Staging
+#-if false
+  dependsOn: []
+#-endif
   jobs:
   - template: build/stage-build.yml
     parameters:

--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -32,13 +32,33 @@
             "**/*.lock.json",
             "**/.vs/**",
             "**/.git/**",
-            "template-scripts/**"
+            "template-scripts/**",
+            "**/stage-dotnetnew.yaml"
+          ],
+          "copyOnly": [
+            "**/*.aprof" 
           ]
         }
       ]
     }
   ],
   "SpecialCustomOperations": {
+    "**/*.yml": {
+      "operations": [
+        {
+          "type": "conditional",
+          "configuration": {
+            "if": [ "#-if" ],
+            "else": [ "#-else" ],
+            "elseif": [ "#-elseif" ],
+            "endif": [ "#-endif" ],
+            "trim": true,
+            "wholeLine": true,
+            "evaluator": "C++"
+          }
+        }
+      ]
+    },
     "**/*.projitems": {
       "operations": [
         {

--- a/build/stage-build.yml
+++ b/build/stage-build.yml
@@ -23,6 +23,15 @@ parameters:
 - name: removeHyperlinksFromReleaseNotes
   type: boolean
   default: false
+- name: pathToSrc
+  type: string
+  default: '$(Build.SourcesDirectory)/src'
+- name: solutionFileName
+  type: string
+  default: '$(SolutionFileName)'
+- name: pathToInfoPlist
+  type: string
+  default: '$(InfoPlistPath)'
 
 jobs:
   - job: On_Windows_ReleaseNotes
@@ -71,6 +80,8 @@ jobs:
     steps:
       - template: steps-build.yml
         parameters:
+          pathToSrc: ${{ parameters.pathToSrc }}
+          solutionFileName: ${{ parameters.solutionFileName }}
           androidKeyStoreFile: ${{ parameters.androidKeyStoreFile }}
 
   - job: On_Mac # Build iOS on a mac
@@ -102,6 +113,9 @@ jobs:
         
     - template: steps-build.yml
       parameters:
+        pathToSrc: ${{ parameters.pathToSrc }}
+        solutionFileName: ${{ parameters.solutionFileName }}
+        pathToInfoPlist: ${{ parameters.pathToInfoPlist }}
         iosProvisioningProfileFile: ${{ parameters.iosProvisioningProfileFile }}
         iosCertificateFile: ${{ parameters.iosCertificateFile }}
         iosCertificatePassword: $(AppleCertificatePassword)

--- a/build/stage-donetnew.yaml
+++ b/build/stage-donetnew.yaml
@@ -1,0 +1,16 @@
+jobs:
+  - job: On_Windows_Dotnet_New
+    pool:
+      name: 'Windows 2022' # .Net 6 is required for the dotnet new to work properly because of this bug: https://github.com/dotnet/templating/pull/2939
+    container: windowsNet6
+    
+    steps:    
+    - script: dotnet new -i $(Build.SourcesDirectory)
+      displayName: 'Install UnoApplicationTemplate'
+
+    - script: dotnet new nv-mobile -n GeneratedApp
+      displayName: 'Generate project using dotnet new'
+
+    - publish: GeneratedApp
+      displayName: 'Publish GeneratedApp folder'
+      artifact: GeneratedApp

--- a/build/steps-build.yml
+++ b/build/steps-build.yml
@@ -11,6 +11,15 @@ parameters:
 - name: iosProvisioningProfileFile
   type: string
   default: ''
+- name: pathToSrc
+  type: string
+  default: ''
+- name: solutionFileName
+  type: string
+  default: ''
+- name: pathToInfoPlist
+  type: string
+  default: ''
 
 steps:
 - task: UseDotNet@2
@@ -19,6 +28,12 @@ steps:
     version: 2.1.x
     packageType: 'runtime'
     installationPath: '$(Agent.ToolsDirectory)/dotnet'
+
+#-if false
+- download: current
+  condition: eq('GeneratedApp.sln', '${{ parameters.solutionFileName }}')
+  artifact: GeneratedApp
+#-endif
 
 - task: gitversion/setup@0
   inputs:
@@ -34,7 +49,7 @@ steps:
 - task: MSBuild@1
   displayName: 'Restore solution packages'
   inputs:
-    solution: $(Build.SourcesDirectory)/src/$(SolutionFileName)
+    solution: '${{ parameters.pathToSrc }}/${{ parameters.solutionFileName }}'
     msbuildLocationMethod: version
     msbuildVersion: latest
     msbuildArchitecture: x86
@@ -74,7 +89,7 @@ steps:
   displayName: "Bump iOS version"
   condition: and(succeeded(), not(eq('${{ parameters.iosProvisioningProfileFile }}', '')))
   inputs:
-    infoPlistPath: $(InfoPlistPath)
+    infoPlistPath: ${{ parameters.pathToInfoPlist }}
     bundleShortVersionString: '$(MajorMinorPatch)'
     bundleVersion: '$(PreReleaseNumber)' 
 
@@ -83,14 +98,14 @@ steps:
   displayName: "Replace iOS bundle identifier"
   condition: and(succeeded(), not(eq('${{ parameters.iosProvisioningProfileFile }}', '')))
   inputs:
-    sourcePath: $(InfoPlistPath)
+    sourcePath: ${{ parameters.pathToInfoPlist }}
     bundleIdentifier: $(ApplicationIdentifier)
     printFile: true
 
 - task: MSBuild@1
   displayName: 'Build solution in $(ApplicationConfiguration) | $(ApplicationPlatform)'
   inputs:
-    solution: $(Build.SourcesDirectory)/src/$(SolutionFileName)
+    solution: '${{ parameters.pathToSrc }}/${{ parameters.solutionFileName }}'
     msbuildLocationMethod: version
     msbuildVersion: latest
     msbuildArchitecture: x86
@@ -114,7 +129,7 @@ steps:
     logProjectEvents: false
     createLogFile: false
 
-- script: dotnet test $(Build.SourcesDirectory)/src/$(SolutionFileName) /p:Configuration=$(ApplicationConfiguration) /p:CollectCoverage=true /p:IncludeTestAssembly=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.SourcesDirectory)/src/coverage /p:ExcludeByFile="**/*.g.cs" /p:Exclude="[*]*.Tests.*" --logger trx --no-build
+- script: dotnet test ${{ parameters.pathToSrc }}/${{ parameters.solutionFileName }} /p:Configuration=$(ApplicationConfiguration) /p:CollectCoverage=true /p:IncludeTestAssembly=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=${{ parameters.pathToSrc }}/coverage /p:ExcludeByFile="**/*.g.cs" /p:Exclude="[*]*.Tests.*" --logger trx --no-build
   displayName: 'Run tests'
   condition: and(succeeded(), eq(variables['ApplicationConfiguration'], 'Release_Tests'))
 
@@ -130,11 +145,21 @@ steps:
   condition: and(succeeded(), eq(variables['ApplicationConfiguration'], 'Release_Tests'))
   inputs:
     codeCoverageTool: 'Cobertura'
-    summaryFileLocation: "$(Build.SourcesDirectory)/src/coverage.cobertura.xml"
+    summaryFileLocation: "${{ parameters.pathToSrc }}/coverage.cobertura.xml"
 
 - publish: $(Build.ArtifactStagingDirectory)
   displayName: 'Publish artifact $(ApplicationConfiguration) | $(ApplicationPlatform)'
   artifact: $(ArtifactName)
+
+#-if false
+- task: DeleteFiles@1
+  displayName: "Remove downloaded artifacts (GeneratedApp folder)"
+  condition: always()
+  inputs:
+    SourceFolder: $(Pipeline.Workspace)/GeneratedApp
+    RemoveSourceFolder: true
+    Contents: '**'
+#-endif
 
 - task: PostBuildCleanup@3
   displayName: 'Post-Build cleanup :  Cleanup files to keep build server clean!'


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Build or CI related changes

## Description

<!-- (Please describe the changes that this PR introduces.) -->

Add automatic CI validation to test the dotnet templating feature.
- Add stage to run `dotnet new nv-mobile -n GeneratedApp`
- Add stage to build the resulting GeneratedApp in Staging.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [x] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [x] Tested on all relevant platforms

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->