### PR TITLE
ci: pass in aab directly to appcenter task

### DIFF
--- a/build/stage-release-appcenter.yml
+++ b/build/stage-release-appcenter.yml
@@ -80,9 +80,11 @@ jobs:
         steps:
 
         - download: current
+          displayName: "Download artifact" 
           artifact: $(artifactName)
 
         - download: current
+          displayName: "Download release notes" 
           artifact: $(releaseNotesArtifactName)
 
         - task: AppCenterDistribute@3
@@ -133,27 +135,12 @@ jobs:
           steps:
 
           - download: current
+            displayName: "Download artifact" 
             artifact: $(artifactName)
 
           - download: current
+            displayName: "Download release notes" 
             artifact: $(releaseNotesArtifactName)
-
-          - task: DownloadSecureFile@1
-            name: keyStore
-            displayName: "Download keystore from secure files"
-            inputs:
-              secureFile: ${{ parameters.androidKeyStoreFile }}
-
-          - task: InstallBundletool@1
-
-          - task: AabConvertToUniversalApk@1
-            inputs:
-              aabFilePath: '$(Pipeline.Workspace)/$(artifactName)/*-Signed.aab'
-              keystoreFilePath: '$(keyStore.secureFilePath)'
-              keystorePassword: '$(AndroidSigningStorePass)'
-              keystoreAlias: '$(AndroidSigningKeyAlias)'
-              keystoreAliasPassword: '$(AndroidSigningKeyPass)'
-              outputFolder: '$(Pipeline.Workspace)/$(artifactName)'
 
           - task: AppCenterDistribute@3
             displayName: Deploy Android to AppCenter
@@ -161,7 +148,7 @@ jobs:
               serverEndpoint: ${{ parameters.appCenterServiceConnectionName }}
               distributionGroupId: ${{ parameters.appCenterDistributionGroup }}
               appSlug: ${{ parameters.appCenterAndroidSlug }}
-              appFile: '$(Pipeline.Workspace)/$(artifactName)/*.apk'
+              appFile: '$(Pipeline.Workspace)/$(artifactName)/*.aab'
               releaseNotesOption: file
               releaseNotesFile: "$(Pipeline.Workspace)/$(releaseNotesArtifactName)/ReleaseNotes-Excerpt.md"
               isSilent: true


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
- Build or CI related changes


## Description

- `AppCenter `now supports pushing aab directly. 
- Removed `BundleTool` task to extract apk from aab as we don't need it anymore.

<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [ ] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [ ] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->