### PR TITLE
fix: 256029 [ALL] Inconsistent Command Bar Behavior

### DIFF
--- a/src/app/ApplicationTemplate.UWP/App.xaml
+++ b/src/app/ApplicationTemplate.UWP/App.xaml
@@ -34,6 +34,7 @@
 				<ResourceDictionary Source="Views/Styles/Controls/DataValidationView.xaml" />
 				<ResourceDictionary Source="Views/Styles/Controls/ExtendedSplashScreen.xaml" />
 				<ResourceDictionary Source="Views/Styles/Controls/FlipViewItem.xaml" />
+				<ResourceDictionary Source="Views/Styles/Controls/Frame.xaml" />
 				<ResourceDictionary Source="Views/Styles/Controls/GridViewHeaderItem.xaml" />
 				<ResourceDictionary Source="Views/Styles/Controls/GridViewItem.xaml" />
 				<ResourceDictionary Source="Views/Styles/Controls/HyperlinkButton.xaml" />

--- a/src/app/ApplicationTemplate.UWP/ApplicationTemplate.UWP.csproj
+++ b/src/app/ApplicationTemplate.UWP/ApplicationTemplate.UWP.csproj
@@ -447,6 +447,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="Views\Styles\Controls\Frame.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Views\Styles\Controls\GridViewHeaderItem.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/src/app/ApplicationTemplate.UWP/Views/Styles/Controls/CommandBar.xaml
+++ b/src/app/ApplicationTemplate.UWP/Views/Styles/Controls/CommandBar.xaml
@@ -2,7 +2,7 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					xmlns:xamarin="http://nventive.com/xamarin"
+					xmlns:xamarin="http://uno.ui/xamarin"
 					xmlns:android="http://nventive.com/android"
 					xmlns:ios="http://nventive.com/ios"
 					xmlns:u="using:Nventive.View.Controls"
@@ -15,124 +15,156 @@
 		https://github.com/unoplatform/uno/blob/master/doc/articles/controls/CommandBar.md
 	-->
 
-	<!-- TODO: Remove when Material fixes the issue it has -->
-	<win:ControlTemplate x:Key="XamlMaterialCommandBarTemplate"
-						 TargetType="CommandBar">
-		<!-- Simplified CommandBar template that adds support for Uno.UI.CommandBarExtensions.NavigationCommand on Windows. -->
-		<Grid x:Name="LayoutRoot"
-			  win:Height="48"
-			  Background="{TemplateBinding Background}">
-
-			<Grid x:Name="ContentRoot"
-				  Margin="{TemplateBinding Padding}"
-				  Background="{TemplateBinding Background}"
-				  Opacity="{TemplateBinding Opacity}">
-
-				<Grid.ColumnDefinitions>
-					<ColumnDefinition Width="Auto" />
-					<ColumnDefinition Width="*" />
-					<ColumnDefinition Width="Auto" />
-				</Grid.ColumnDefinitions>
-
-				<!-- note: NavigationCommand is an AppBarButton, not ICommand -->
-				<ContentControl Content="{Binding (toolkit:CommandBarExtensions.NavigationCommand), RelativeSource={RelativeSource TemplatedParent}}"
-								Foreground="{TemplateBinding Foreground}"
-								Height="{StaticResource MaterialCommandBarHeight}"
-								Width="{StaticResource MaterialCommandBarHeight}"
-								IsTabStop="False" />
-
-				<!--
-					Use a ContentControl rather than a ContentPresenter so that IsEnabled can be set to false
-					in the Minimal/HiddenClosed states to remove it from being a tab-stop candidate.
-				-->
-				<ContentControl x:Name="ContentControl"
-								Grid.Column="1"
-								Margin="16,0"
-								Content="{TemplateBinding Content}"
-								ContentTemplate="{TemplateBinding ContentTemplate}"
-								ContentTransitions="{TemplateBinding ContentTransitions}"
-								Foreground="{TemplateBinding Foreground}"
-								HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-								VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-								HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-								VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-								IsTabStop="False" />
-
-				<ItemsControl x:Name="PrimaryItemsControl"
-							  HorizontalAlignment="Right"
-							  MinHeight="{ThemeResource AppBarThemeCompactHeight}"
-							  IsTabStop="False"
-							  Grid.Column="2">
-					<ItemsControl.ItemsPanel>
-						<ItemsPanelTemplate>
-							<StackPanel Orientation="Horizontal" />
-						</ItemsPanelTemplate>
-					</ItemsControl.ItemsPanel>
-				</ItemsControl>
-			</Grid>
-		</Grid>
-	</win:ControlTemplate>
-
-	<win:Style x:Key="MaterialCommandBarStyle"
-			   TargetType="CommandBar">
-		<!-- Setting content to empty to avoid getting the datacontext -->
-		<Setter Property="Content"
-				Value="" />
-		<Setter Property="ContentTemplate">
-			<Setter.Value>
-				<DataTemplate>
-					<TextBlock Text="{Binding}"
-							   Style="{StaticResource Headline6}" />
-				</DataTemplate>
-			</Setter.Value>
-		</Setter>
-
-		<Setter Property="Height"
-				Value="{StaticResource MaterialCommandBarHeight}" />
-
-		<Setter Property="HorizontalAlignment"
-				Value="Stretch" />
-		<Setter Property="VerticalAlignment"
-				Value="Top" />
-		<Setter Property="HorizontalContentAlignment"
-				Value="Left" />
-		<Setter Property="VerticalContentAlignment"
-				Value="Center" />
-
-		<Setter Property="OverflowButtonVisibility"
-				Value="Collapsed" />
-		<Setter Property="IsDynamicOverflowEnabled"
-				Value="False" />
-
-		<Setter Property="Template"
-				Value="{StaticResource XamlMaterialCommandBarTemplate}" />
-	</win:Style>
-
 	<Style x:Key="DefaultCommandBarStyle"
 		   TargetType="CommandBar"
-		   BasedOn="{StaticResource MaterialCommandBarStyle}">
+		   xamarin:BasedOn="{StaticResource NativeDefaultCommandBar}">
+
+		<!-- COMMON SETTERS -->
 		<Setter Property="toolkit:CommandBarExtensions.BackButtonForeground"
 				Value="{StaticResource MaterialSurfaceBrush}" />
 		<Setter Property="Background"
 				Value="{ThemeResource MaterialOnBackgroundBrush}" />
 		<Setter Property="Foreground"
 				Value="{ThemeResource MaterialSurfaceBrush}" />
-		<Setter Property="Height"
-				Value="56" />
+
+		<!-- StatusBarThickness Padding set here in order to fix those two known issues:
+				On iOS the content will be underneath the CommandBar
+				On Android the CommandBar will be underneath the StatusBar
+				The "StatusBarThickness" resource is one which is programmatically added at runtime, with a value that changes depending on the platform/device. -->
+		<Setter Property="Padding"
+				Value="{StaticResource StatusBarThickness}" />
+		<!-- Uncomment when android is fixed -->
+		<!--<Setter Property="toolkit:VisibleBoundsPadding.PaddingMask"
+				Value="Top" />-->
+
+		<!-- Setting content to empty to avoid getting the datacontext-->
+		<Setter Property="Content"
+				Value="" />
+
+		<!-- ANDROID SETTERS -->
+		<android:Setter Property="toolkit:UIElementExtensions.Elevation"
+						Value="4" />
+
+		<!-- IOS SETTERS -->
+		<!-- Remove the back button title (and only leave the back arrow) -->
+		<ios:Setter Property="(toolkit:CommandBarExtensions.BackButtonTitle)"
+					Value="" />
+		<ios:Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="CommandBar">
+					<!-- 
+						Context:
+						On iOS, all pages share the same UINavigationBar instance.
+						During a transition from two pages with different CommandBar colors, the shared UINavigationBar bar instance can only display one of those colors.
+					
+						Example:
+						Page A has an opaque CommandBar and Page B has a transparent CommandBar.
+						When transitioning from Page A to Page B, the shared UINavigationBar instance becomes transparent, which reveals a white space at the top of Page A.
+					
+						Solution:
+						To circumvent this issue, we duplicate the background color of the UINavigationBar with this Border.
+						Note that this only works because we're not using semi-transparent background colors (which would add up and look off). 
+					-->
+					<Border BorderBrush="{TemplateBinding Background}"
+							BorderThickness="{TemplateBinding Padding}"
+							Background="{TemplateBinding Background}">
+						<NativeCommandBarPresenter Height="44" />
+					</Border>
+				</ControlTemplate>
+			</Setter.Value>
+		</ios:Setter>
+
+		<win:Setter Property="Height"
+					Value="40" />
+
+		<win:Setter Property="ContentTemplate">
+			<Setter.Value>
+				<DataTemplate>
+					<TextBlock Text="{Binding}"
+							   Style="{StaticResource Headline6}"
+							   Foreground="{ThemeResource MaterialSurfaceBrush}"
+							   Margin="30,0,0,0"/>
+				</DataTemplate>
+			</Setter.Value>
+		</win:Setter>
+
+		<!-- Simplified CommandBar template that adds support for Uno.UI.CommandBarExtensions.NavigationCommand on Windows. -->
+		<win:Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="CommandBar">
+					
+					<Grid x:Name="LayoutRoot"
+						  Height="{TemplateBinding Height}"
+						  Background="{TemplateBinding Background}">
+
+						<Grid x:Name="ContentRoot"
+							  VerticalAlignment="Top"
+							  Margin="{TemplateBinding Padding}"
+							  Height="{TemplateBinding Height}"
+							  Background="{TemplateBinding Background}"
+							  Opacity="{TemplateBinding Opacity}">
+
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="Auto" />
+								<ColumnDefinition Width="*" />
+								<ColumnDefinition Width="Auto" />
+							</Grid.ColumnDefinitions>
+
+							<ContentControl x:Name="NavigationCommand"
+											Grid.Column="0"
+											IsTabStop="False"
+											Foreground="{TemplateBinding Foreground}"
+											Content="{Binding (toolkit:CommandBarExtensions.NavigationCommand), RelativeSource={RelativeSource TemplatedParent}}" />
+
+							<!-- Use a ContentControl rather than a ContentPresenter so that IsEnabled can be set to false
+								 in the Minimal/HiddenClosed states to remove it from being a tab-stop candidate. -->
+							<ContentControl x:Name="ContentControl"
+											Grid.Column="1"
+											HorizontalContentAlignment="Stretch"
+											VerticalContentAlignment="Center"
+											HorizontalAlignment="Stretch"
+											VerticalAlignment="Stretch"
+											Content="{TemplateBinding Content}"
+											ContentTemplate="{TemplateBinding ContentTemplate}"
+											Foreground="{TemplateBinding Foreground}"
+											IsTabStop="False" />
+							
+							<ItemsControl x:Name="PrimaryItemsControl"
+										  HorizontalAlignment="Right"
+										  MinHeight="{ThemeResource AppBarThemeMinHeight}"
+										  IsTabStop="False"
+										  Grid.Column="2">
+								<ItemsControl.ItemsPanel>
+									<ItemsPanelTemplate>
+										<StackPanel Orientation="Horizontal" />
+									</ItemsPanelTemplate>
+								</ItemsControl.ItemsPanel>
+							</ItemsControl>
+							
+							<Rectangle x:Name="HighContrastBorder"
+									   Grid.ColumnSpan="3"
+									   x:DeferLoadStrategy="Lazy"
+									   Visibility="Collapsed"
+									   VerticalAlignment="Stretch"
+									   Stroke="{ThemeResource SystemControlForegroundTransparentBrush}"
+									   StrokeThickness="1" />
+						</Grid>
+					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</win:Setter>
 	</Style>
 
 	<Style x:Key="TransparentCommandBarStyle"
-		   TargetType="CommandBar">
-		<Setter Property="toolkit:CommandBarExtensions.BackButtonForeground"
-				Value="{StaticResource MaterialSurfaceBrush}" />
-		<Setter Property="Height"
-				Value="56" />
+		   TargetType="CommandBar"
+		   BasedOn="{StaticResource DefaultCommandBarStyle}">
+
 		<Setter Property="Background"
 				Value="Transparent" />
-		<Setter Property="Foreground"
-				Value="{StaticResource MaterialSurfaceBrush}" />
+		<Setter Property="toolkit:UIElementExtensions.Elevation"
+				Value="0" />
 	</Style>
-	
+
 	<!-- Default Style -->
 	<Style TargetType="CommandBar"
 		   BasedOn="{StaticResource DefaultCommandBarStyle}" />

--- a/src/app/ApplicationTemplate.UWP/Views/Styles/Controls/Frame.xaml
+++ b/src/app/ApplicationTemplate.UWP/Views/Styles/Controls/Frame.xaml
@@ -1,0 +1,59 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:android="http://nventive.com/android"
+                    xmlns:ios="http://nventive.com/ios"
+                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    xmlns:uic="using:Uno.UI.Controls"
+                    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:xamarin="http://uno.ui/xamarin"
+                    mc:Ignorable="ios android xamarin">
+
+	<ios:Style x:Key="NativeDefaultFrame"
+               TargetType="Frame">
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="Frame">
+					<uic:NativeFramePresenter Background="{TemplateBinding Background}" />
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</ios:Style>
+
+	<android:Style x:Key="NativeDefaultFrame"
+                   TargetType="Frame">
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="Frame">
+					<uic:NativeFramePresenter Background="{TemplateBinding Background}" />
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</android:Style>
+
+	<win:Style x:Key="NativeDefaultFrame"
+               TargetType="Frame">
+		<Setter Property="HorizontalContentAlignment" Value="Stretch" />
+		<Setter Property="IsTabStop" Value="False" />
+		<Setter Property="VerticalContentAlignment" Value="Stretch" />
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="Frame">
+					<ContentPresenter Padding="{TemplateBinding Padding}"
+                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                      Background="{TemplateBinding Background}"
+                                      BorderBrush="{TemplateBinding BorderBrush}"
+                                      BorderThickness="{TemplateBinding BorderThickness}"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      ContentTransitions="{TemplateBinding ContentTransitions}" />
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</win:Style>
+
+	<Style xamarin:IsNativeStyle="True"
+           BasedOn="{StaticResource NativeDefaultFrame}"
+           TargetType="Frame" />
+
+</ResourceDictionary>


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix


## Description

For some reason the commit f73c0351 introduced bug with the command bar on iOS. Upon inspection it seems to be caused by the line `<ToolkitResources xmlns="using:Uno.Toolkit.UI" />` added in `App.xaml`. Since it was needed to have the TabBar properly functioning on UWP I change the location of `<ToolkitResources xmlns="using:Uno.Toolkit.UI" />`. On Android the command bar was the same size as the status bar so I set the `height` manually.  

###Before
![Android](https://user-images.githubusercontent.com/64613932/174386122-e5f4e0c0-2fc5-4778-a25e-49ab66cbae98.png)
![iOS](https://user-images.githubusercontent.com/64613932/174386209-6fbf1bf0-6f8f-4c93-b15a-d9c8cee26aed.png)

###After
![image](https://user-images.githubusercontent.com/64613932/174386428-7cee48cc-8029-49cc-b16b-5d38045f3304.png)
![image](https://user-images.githubusercontent.com/64613932/174386855-f6dee855-c5c0-45af-ae7a-0c70b8dfc04e.png)

## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] ~~Interface members are XML documented~~
- [ ] ~~Documentation (XML or comments) has been added and/or existing documentation has been updated~~
- [ ] ~~[Architecture documents](./doc/Architecture.md) have been updated~~
- [x] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
[ALL] Inconsistent Command Bar Behavior
https://dev.azure.com/nventive/Practice%20committees/_boards/board/t/Mobile%20(.Net)/Features/?workitem=256029