### PR TITLE
fix: [Android/iOS] [Login] The user is able to login with an invalid email address

### DIFF
--- a/src/app/ApplicationTemplate.Shared/Presentation/Authentication/CreateAccountFormViewModel.cs
+++ b/src/app/ApplicationTemplate.Shared/Presentation/Authentication/CreateAccountFormViewModel.cs
@@ -86,7 +86,7 @@ namespace ApplicationTemplate.Presentation
 			RuleFor(x => x.Email)
 				.NotEmpty()
 				.WithMessage(_ => localizer["ValidationNotEmpty_Email"])
-				.EmailAddress()
+				.IsValidEmail()
 				.WithMessage(_ => localizer["ValidationError_Email"]);
 
 			RuleFor(x => x.PhoneNumber)

--- a/src/app/ApplicationTemplate.Shared/Presentation/Authentication/ForgotPasswordFormViewModel.cs
+++ b/src/app/ApplicationTemplate.Shared/Presentation/Authentication/ForgotPasswordFormViewModel.cs
@@ -5,6 +5,7 @@ using Chinook.DynamicMvvm;
 using FluentValidation;
 using FluentValidation.Validators;
 using Microsoft.Extensions.Localization;
+using Presentation;
 
 namespace ApplicationTemplate.Presentation
 {
@@ -29,7 +30,7 @@ namespace ApplicationTemplate.Presentation
 			RuleFor(x => x.Email)
 				.NotEmpty()
 				.WithMessage(_ => localizer["ValidationNotEmpty_Email"])
-				.EmailAddress()
+				.IsValidEmail()
 				.WithMessage(_ => localizer["ValidationError_Email"]);
 		}
 	}

--- a/src/app/ApplicationTemplate.Shared/Presentation/Authentication/LoginFormViewModel.cs
+++ b/src/app/ApplicationTemplate.Shared/Presentation/Authentication/LoginFormViewModel.cs
@@ -5,6 +5,7 @@ using Chinook.DynamicMvvm;
 using FluentValidation;
 using FluentValidation.Validators;
 using Microsoft.Extensions.Localization;
+using Presentation;
 
 namespace ApplicationTemplate.Presentation
 {
@@ -36,7 +37,7 @@ namespace ApplicationTemplate.Presentation
 			RuleFor(x => x.Email)
 				.NotEmpty()
 				.WithMessage(_ => localizer["ValidationNotEmpty_Email"])
-				.EmailAddress()
+				.IsValidEmail()
 				.WithMessage(_ => localizer["ValidationError_Email"]);
 			RuleFor(x => x.Password)
 				.NotEmpty()


### PR DESCRIPTION

GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

## Description

Email validation on FluentValidation is deprecated so I added a RegEx to validate the email address string.

Essentially went with the method propose in Microsoft documentation on email validation
https://docs.microsoft.com/en-us/dotnet/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format


## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] ~~Interface members are XML documented~~
- [ ] ~~Documentation (XML or comments) has been added and/or existing documentation has been updated~~
- [ ] ~~[Architecture documents](./doc/Architecture.md) have been updated~~
- [x] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

https://docs.microsoft.com/en-us/dotnet/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format
https://dev.azure.com/nventive/Practice%20committees/_workitems/edit/252828