### PR TITLE
feat: Clean up SettingsPage.xaml

### DIFF
--- a/src/app/ApplicationTemplate.UWP/Views/Content/Settings/SettingsPage.xaml
+++ b/src/app/ApplicationTemplate.UWP/Views/Content/Settings/SettingsPage.xaml
@@ -1,12 +1,11 @@
 ﻿<Page x:Class="ApplicationTemplate.Views.Content.SettingsPage"
 	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:ue="using:Nventive.View.Extensions"
 	  xmlns:u="using:Nventive.View.Controls"
 	  xmlns:dl="using:Chinook.DataLoader"
-	  mc:Ignorable="d">
+	  mc:Ignorable="">
 
 	<Grid Background="{StaticResource MaterialBackgroundBrush}">
 
@@ -15,56 +14,74 @@
 			<RowDefinition Height="*" />
 		</Grid.RowDefinitions>
 
+		<!-- CommandBar -->
 		<CommandBar Content="Profile"
 					x:Uid="Settings_CommandBar" />
 
 		<ScrollViewer Grid.Row="1">
-
 			<StackPanel>
+
+				<!-- DataLoaderView -->
 				<dl:DataLoaderView Source="{Binding UserProfile}"
 								   MinHeight="270">
 					<DataTemplate>
-						<StackPanel Padding="24">
-							<!-- Name and Lastname -->
-							<TextBlock Style="{StaticResource Headline5}">
-									<Run Text="{Binding Data.FirstName}" /><Run
-											Text=" " /><Run
-											Text="{Binding Data.LastName}" />
-							</TextBlock>
+						<StackPanel>
 
-							<!-- Email -->
-							<TextBlock Text="Email"
-										x:Uid="Settings_Email"
-										Margin="0,15,0,0"
-										Style="{StaticResource Subtitle2}" />
-							<TextBlock Text="{Binding Data.Email}"
-										Style="{StaticResource Body2}" />
+							<!-- User Info Section -->
+							<StackPanel Padding="24,24,24,0">
 
-							<Rectangle Margin="0,15"
-										Height="1"
-										HorizontalAlignment="Stretch"
-										Fill="{StaticResource MaterialOnSurfacePressedBrush}" />
+								<!-- Full Name -->
+								<TextBlock Style="{StaticResource Headline5}">
+									
+									<!-- First Name -->
+									<Run Text="{Binding Data.FirstName}" />
 
-							<!-- Password -->
-							<TextBlock Text="Password"
-										x:Uid="Settings_Password"
-										Style="{StaticResource Subtitle2}" />
-							<TextBlock Text="xxxxxxxx"
-										Style="{StaticResource Body2}" />
+									<!-- Last Name -->
+									<Run Text="{Binding Data.LastName}" />
+								</TextBlock>
 
-							<!-- Change password -->
-							<Button Content="CHANGE PASSWORD"
-									x:Uid="Settings_ChangePassword"
-									Margin="0,15,0,0"
-									HorizontalAlignment="Left"
-									Command="{Binding Parent.NavigateToResetPasswordPage}" />
+								<!-- Email Label -->
+								<TextBlock Text="Email"
+									   x:Uid="Settings_Email"
+									   Style="{StaticResource Subtitle2}"
+									   Margin="0,16,0,0" />
+
+								<!-- Email Value -->
+								<TextBlock Text="{Binding Data.Email}"
+										   Style="{StaticResource Body2}" />
+							</StackPanel>
+							
+							<!-- Separator -->
+							<Rectangle Fill="{StaticResource SeparatorBrush}"
+									Height="1"
+									HorizontalAlignment="Stretch"
+									Margin="0,16,0,0" />
+
+							<!-- Password Section -->
+							<StackPanel Padding="24,16,24,0">
+								
+								<!-- Password -->
+								<TextBlock Text="Password"
+											x:Uid="Settings_Password"
+											Style="{StaticResource Subtitle2}" />
+								<TextBlock Text="xxxxxxxx"
+											Style="{StaticResource Body2}" />
+
+								<!-- Change password -->
+								<Button Content="CHANGE PASSWORD"
+										x:Uid="Settings_ChangePassword"
+										Command="{Binding Parent.NavigateToResetPasswordPage}"
+										HorizontalAlignment="Left"
+										Margin="0,16,0,0" />
+							</StackPanel>
 						</StackPanel>
 					</DataTemplate>
 				</dl:DataLoaderView>
 
-				<Rectangle Height="1"
-						   HorizontalAlignment="Stretch"
-						   Fill="{StaticResource MaterialOnSurfacePressedBrush}" />
+				<!-- Separator -->
+				<Rectangle Fill="{StaticResource SeparatorBrush}" 
+						   Height="1"
+						   HorizontalAlignment="Stretch" />
 
 				<StackPanel Margin="24,16">
 
@@ -72,31 +89,38 @@
 					<Grid Background="Transparent"
 						  ue:MultipleTapExtension.Command="{Binding NavigateToDiagnosticsPage}"
 						  ue:MultipleTapExtension.TapCount="3">
+
 						<TextBlock Style="{StaticResource Subtitle2}">
-						<Run Text="DAD Jokes - Version"
-							 x:Uid="Settings_Version" /><Run
-							 Text=" " /><Run
-							 Text="{Binding VersionNumber}" />
+
+							<!-- Label -->
+							<Run Text="DAD Jokes - Version"
+								 x:Uid="Settings_Version" />
+
+							<!-- Value -->
+							<Run Text="{Binding VersionNumber}" />
 						</TextBlock>
 					</Grid>
 
+					<!-- API Info -->
 					<TextBlock Text="This application makes use of the dadjokes API from Dadjokes.io, which contains thousands of jokes."
 							   x:Uid="Settings_Version_Details"
 							   Style="{StaticResource Body2}"
-							   Foreground="{StaticResource MaterialOnSurfaceMediumBrush}" />
+							   Foreground="{StaticResource MaterialOnBackgroundBrush}"
+							   Opacity="{StaticResource MaterialMediumOpacity}"/>
 
 					<!-- Replay tutorial -->
 					<Button Content="REPLAY TUTORIAL"
 							x:Uid="Settings_ReplayTutorial"
-							Margin="0,16,0,0"
-							HorizontalAlignment="Left"
 							Command="{Binding NavigateToOnboardingPage}"
-							Style="{StaticResource MaterialContainedSecondaryButtonStyle}" />
+							Style="{StaticResource MaterialContainedSecondaryButtonStyle}"
+							HorizontalAlignment="Left"
+							Margin="0,16,0,0" />
 				</StackPanel>
 
-				<Rectangle Height="1"
-						   HorizontalAlignment="Stretch"
-						   Fill="{StaticResource MaterialOnSurfacePressedBrush}" />
+				<!-- Separator -->
+				<Rectangle Fill="{StaticResource SeparatorBrush}" 
+						   Height="1"
+						   HorizontalAlignment="Stretch" />
 
 				<!-- Notification -->
 				<Grid Margin="24,16,20,16">
@@ -105,70 +129,85 @@
 						<ColumnDefinition Width="Auto" />
 					</Grid.ColumnDefinitions>
 
-					<StackPanel>
+					<StackPanel VerticalAlignment="Center">
+						
+						<!-- Label -->
 						<TextBlock Text="Notification"
 								   x:Uid="Settings_Notification"
 								   Style="{StaticResource Subtitle2}" />
+						
+						<!-- Info -->
 						<TextBlock Text="I agree to receive notifications when there are new jokes."
 								   x:Uid="Settings_Notification_Details"
 								   Style="{StaticResource Body2}" />
 					</StackPanel>
 
-					<ToggleSwitch Grid.Column="1"
-								  Margin="20,0,0,0" />
+					<!-- ToggleSwitch -->
+					<ToggleSwitch VerticalAlignment="Center"
+								  Margin="20,0,0,0"
+								  Grid.Column="1" />
 				</Grid>
 
-				<Rectangle Height="1"
-						   HorizontalAlignment="Stretch"
-						   Fill="{StaticResource MaterialOnSurfacePressedBrush}" />
+				<!-- Separator -->
+				<Rectangle Fill="{StaticResource SeparatorBrush}" 
+						   Height="1"
+						   HorizontalAlignment="Stretch" />
 
 				<!-- Dark Mode  -->
-				<Grid Margin="24,18,20,18">
+				<Grid Margin="24,0,20,0"
+					  MinHeight="60">
 					<Grid.ColumnDefinitions>
 						<ColumnDefinition Width="*" />
 						<ColumnDefinition Width="Auto" />
 					</Grid.ColumnDefinitions>
 
+					<!-- Label -->
 					<TextBlock Text="Dark mode"
 							   x:Uid="Settings_DarkMode"
-							   Style="{StaticResource Subtitle2}" />
+							   Style="{StaticResource Subtitle2}"
+							   VerticalAlignment="Center" />
 
-					<ToggleSwitch Grid.Column="1"
-								  Toggled="OnThemeButtonClicked"
-								  Margin="20,0,0,0" />
+					<!-- ToggleSwitch -->
+					<ToggleSwitch Toggled="OnThemeButtonClicked"
+								  VerticalAlignment="Center"
+								  Margin="20,0,0,0"
+								  Grid.Column="1" />
 				</Grid>
 
-				<Rectangle Height="1"
-						   HorizontalAlignment="Stretch"
-						   Fill="{StaticResource MaterialOnSurfacePressedBrush}" />
+				<!-- Separator -->
+				<Rectangle Fill="{StaticResource SeparatorBrush}" 
+						   Height="1"
+						   HorizontalAlignment="Stretch" />
 
-				<!-- Privacy policy  -->
+				<!-- Privacy Policy Button -->
 				<Button Content="Privacy policy"
 						x:Uid="Settings_PrivacyPolicy"
 						Command="{Binding NavigateToPrivacyPolicyPage}"
 						Style="{StaticResource MaterialTextWithRightArrowAlternativeButtonStyle}" />
 
-				<Rectangle Height="1"
-						   HorizontalAlignment="Stretch"
-						   Fill="{StaticResource MaterialOnSurfacePressedBrush}" />
+				<!-- Separator -->
+				<Rectangle Fill="{StaticResource SeparatorBrush}" 
+						   Height="1"
+						   HorizontalAlignment="Stretch" />
 
-				<!-- Terms & conditions  -->
+				<!-- Terms & Conditions Button -->
 				<Button Content="Terms &amp; conditions"
 						x:Uid="Settings_TermsAndConditions"
 						Command="{Binding NavigateToTermsAndConditionsPage}"
 						Style="{StaticResource MaterialTextWithRightArrowAlternativeButtonStyle}" />
 
-				<Rectangle Height="1"
-						   HorizontalAlignment="Stretch"
-						   Fill="{StaticResource MaterialOnSurfacePressedBrush}" />
+				<!-- Separator -->
+				<Rectangle Fill="{StaticResource SeparatorBrush}" 
+						   Height="1"
+						   HorizontalAlignment="Stretch"/>
 
 				<!-- Logout -->
 				<Button Content="LOGOUT"
 						x:Uid="Settings_Logout"
-						Margin="24,16"
-						HorizontalAlignment="Left"
 						Command="{Binding Logout}"
-						Background="{StaticResource MaterialErrorBrush}" />
+						Background="{StaticResource MaterialPrimaryAccentBrush}"
+						HorizontalAlignment="Left"
+						Margin="24,16" />
 			</StackPanel>
 		</ScrollViewer>
 	</Grid>

--- a/src/app/ApplicationTemplate.UWP/Views/Styles/Application/Brushes.xaml
+++ b/src/app/ApplicationTemplate.UWP/Views/Styles/Application/Brushes.xaml
@@ -14,6 +14,13 @@
 					 Color="{ThemeResource MaterialSuccessColor}" />
 	<SolidColorBrush x:Key="MaterialOnSuccessBrush"
 					 Color="{ThemeResource MaterialOnSuccessColor}" />
+
+	<SolidColorBrush x:Key="MaterialPrimaryAccentBrush"
+					 Color="{ThemeResource MaterialPrimaryAccentColor}" />
+	
+	<SolidColorBrush x:Key="SeparatorBrush"
+					 Color="{ThemeResource MaterialOnSurfaceColor}"
+					 Opacity="0.12"/>
 	
 	<!-- ToggleSwitch Brushes -->
 
@@ -30,5 +37,4 @@
 					ResourceKey="MaterialOnSurfaceMediumBrush" />
 	<StaticResource x:Key="MaterialToggleSwitchOnLowBackgroundBrush"
 					ResourceKey="MaterialOnSurfaceSelectedBrush" />
-
 </ResourceDictionary>


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Feature

## Description

General clean up of the xaml file that include stuff like:
Added comments to organize code
Reorganize the order of properties in control in a more logical manner 
Remove unecessary blend using
Ensure proper use of material color ressources
Reorganization of layout (like using stack panels instead of mannually defines rows)
Make sure Margin and Padding are set using multiples of 4 (When it does not disturb design)
Removing property that use default values


## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] ~~Interface members are XML documented~~
- [ ] ~~Documentation (XML or comments) has been added and/or existing documentation has been updated~~
- [ ] ~~[Architecture documents](./doc/Architecture.md) have been updated~~
- [x] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
Clean up SettingsPage.xaml
https://dev.azure.com/nventive/Practice%20committees/_workitems/edit/259233