### PR TITLE
feat: Clean up EditPostPage.xaml

### DIFF
--- a/src/app/ApplicationTemplate.UWP/Views/Content/Posts/EditPostPage.xaml
+++ b/src/app/ApplicationTemplate.UWP/Views/Content/Posts/EditPostPage.xaml
@@ -3,10 +3,9 @@
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	  xmlns:local="using:ApplicationTemplate"
 	  xmlns:uc="using:Nventive.View.Converters"
-	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:toolkit="using:Uno.UI.Toolkit"
-	  mc:Ignorable="d">
+	  mc:Ignorable="">
 
 	<Grid Background="{StaticResource MaterialBackgroundBrush}">
 
@@ -15,10 +14,14 @@
 			<RowDefinition Height="*" />
 		</Grid.RowDefinitions>
 
+		<!-- CommandBar -->
 		<CommandBar Content="{Binding Title}">
 			<toolkit:CommandBarExtensions.NavigationCommand>
-				<AppBarButton Command="{Binding Cancel}">
+				<AppBarButton Command="{Binding Cancel}"
+							  Foreground="{StaticResource MaterialBackgroundBrush}">
 					<AppBarButton.Icon>
+
+						<!-- Icon -->
 						<BitmapIcon UriSource="ms-appx:///Assets/CommandBarCommands/closeIcon.png" />
 					</AppBarButton.Icon>
 				</AppBarButton>
@@ -31,34 +34,38 @@
 			<StackPanel DataContext="{Binding Form}">
 
 				<!-- Title -->
-				<local:DataValidationView Model="{Binding}"
-										  PropertyName="Title"
+				<local:DataValidationView PropertyName="Title"
+										  Model="{Binding}"
 										  Margin="0,4">
 					<TextBox Text="{Binding Title, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-							 CornerRadius="4"
-							 x:Uid="EditPost_JokeTitle"
 							 PlaceholderText="Joke's title"
+							 x:Uid="EditPost_JokeTitle"
+							 CornerRadius="4"
 							 FontSize="16" />
 				</local:DataValidationView>
 
 				<!-- Body -->
-				<local:DataValidationView Model="{Binding}"
-										  PropertyName="Body"
+				<local:DataValidationView PropertyName="Body"
+										  Model="{Binding}"
 										  Margin="0,4">
 					<TextBox Text="{Binding Body, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-							 x:Uid="EditPost_JokeContent"
-							 PlaceholderText="Write the joke" />
+							 PlaceholderText="Write the joke" 
+							 x:Uid="EditPost_JokeContent"/>
 				</local:DataValidationView>
 			</StackPanel>
 
 			<StackPanel Orientation="Horizontal"
 						HorizontalAlignment="Right">
+
+				<!-- Cancel Button -->
 				<Button Content="Cancel"
 						x:Uid="EditPost_Cancel"
 						Command="{Binding Cancel}"
 						Style="{StaticResource MaterialOutlinedButtonStyle}"
 						HorizontalAlignment="Stretch"
 						Margin="5" />
+
+				<!-- Save Button -->
 				<Button Content="Save"
 						x:Uid="EditPost_Save"
 						Command="{Binding Save}"

--- a/src/app/ApplicationTemplate.UWP/Views/Styles/Controls/CommandBar.xaml
+++ b/src/app/ApplicationTemplate.UWP/Views/Styles/Controls/CommandBar.xaml
@@ -113,11 +113,11 @@
 		   TargetType="CommandBar"
 		   BasedOn="{StaticResource MaterialCommandBarStyle}">
 		<Setter Property="toolkit:CommandBarExtensions.BackButtonForeground"
-				Value="{StaticResource MaterialSurfaceBrush}" />
+				Value="{StaticResource MaterialBackgroundBrush}" />
 		<Setter Property="Background"
 				Value="{ThemeResource MaterialOnBackgroundBrush}" />
 		<Setter Property="Foreground"
-				Value="{ThemeResource MaterialSurfaceBrush}" />
+				Value="{ThemeResource MaterialBackgroundBrush}" />
 		<android:Setter Property="Height"
 						Value="100" />
 	</Style>


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Feature

## Description

General clean up of the xaml file that include stuff like:
Added comments to organize code
Reorganize the order of properties in control in a more logical manner
Remove unnecessary blend using
Ensure proper use of material color resources
Reorganization of layout (like using stack panels instead of manually defines rows)
Make sure Margin and Padding are set using multiples of 4 (When it does not disturb design)
Removing property that use default values


## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] ~~Interface members are XML documented~~
- [ ] ~~Documentation (XML or comments) has been added and/or existing documentation has been updated~~
- [ ] ~~[Architecture documents](./doc/Architecture.md) have been updated~~
- [x] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
Clean up EditPostPage.xaml
https://dev.azure.com/nventive/Practice%20committees/_workitems/edit/259230