### PR TITLE
feat: Clean up DiagnosticsPage.xaml

### DIFF
--- a/src/app/ApplicationTemplate.UWP/Views/Content/Diagnostics/DiagnosticsPage.xaml
+++ b/src/app/ApplicationTemplate.UWP/Views/Content/Diagnostics/DiagnosticsPage.xaml
@@ -2,9 +2,8 @@
 	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	  xmlns:local="using:ApplicationTemplate"
-	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	  mc:Ignorable="d">
+	  mc:Ignorable="">
 
 	<Grid Background="{StaticResource MaterialBackgroundBrush}">
 
@@ -13,16 +12,17 @@
 			<RowDefinition Height="*" />
 		</Grid.RowDefinitions>
 
+		<!-- CommandBar -->
 		<CommandBar Content="Diagnostics">
 			<CommandBar.PrimaryCommands>
 				<AppBarButton Content="Close"
-							  Foreground="White"
+							  Foreground="{StaticResource MaterialOnBackgroundBrush}"
 							  Command="{Binding CloseModal}" />
 			</CommandBar.PrimaryCommands>
 		</CommandBar>
 
 		<ScrollViewer Grid.Row="1">
-			<StackPanel Margin="20,0,20,20">
+			<StackPanel Margin="20">
 
 				<!-- Environment picker -->
 				<Button Command="{Binding NavigateToEnvironmentPickerPage}"
@@ -39,19 +39,21 @@
 							<ColumnDefinition Width="Auto" />
 						</Grid.ColumnDefinitions>
 
+						<!-- Label -->
 						<TextBlock Text="Environment"
 								   VerticalAlignment="Center" />
 
+						<!-- Current Value -->
 						<TextBlock Text="{Binding CurrentEnvironment}"
 								   VerticalAlignment="Center"
 								   HorizontalAlignment="Right"
 								   Grid.Column="1" />
 
+						<!-- Icon -->
 						<Path Data="{StaticResource ChevronIcon}"
+							  Fill="{StaticResource MaterialOnPrimaryBrush}"
 							  VerticalAlignment="Center"
-							  HorizontalAlignment="Right"
 							  Margin="16,0,4,0"
-							  Fill="Black"
 							  Grid.Column="2" />
 					</Grid>
 				</Button>
@@ -59,18 +61,21 @@
 				<!-- Summary -->
 				<StackPanel DataContext="{Binding SummaryDiagnostics}">
 
+					<!-- Label -->
 					<TextBlock Text="SUMMARY"
 							   FontWeight="Bold"
 							   Margin="0,24,0,8" />
 
-					<Border Background="Black"
+					<!-- Value -->
+					<Border Background="{StaticResource MaterialPrimaryDarkBrush}"
 							Padding="8,4">
 						<TextBlock Text="{Binding Summary}"
 								   FontSize="11"
-								   Foreground="White"
-								   TextWrapping="WrapWholeWords" />
+								   Foreground="{StaticResource MaterialOnPrimaryBrush}"
+								   TextWrapping="Wrap" />
 					</Border>
 
+					<!-- Send Summary Button -->
 					<Button Content="Send summary with logs"
 							Command="{Binding SendSummary}"
 							HorizontalAlignment="Stretch"
@@ -79,6 +84,8 @@
 
 				<!-- Localization -->
 				<StackPanel>
+					
+					<!-- Label -->
 					<TextBlock Text="LOCALIZATION"
 							   FontWeight="Bold"
 							   Margin="0,24,0,8" />
@@ -90,18 +97,22 @@
 							<ColumnDefinition Width="Auto" />
 						</Grid.ColumnDefinitions>
 
+						<!-- Value -->
 						<TextBox Text="{Binding Culture, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
+						<!-- Set Culture Button -->
 						<Button Content="Set culture"
-								Padding="12"
-								Margin="5,0,0,0"
 								Command="{Binding SaveCulture}"
+								Padding="12"
+								Margin="16,0,0,0"
 								Grid.Column="1" />
 					</Grid>
 				</StackPanel>
 
 				<!-- Settings -->
 				<StackPanel DataContext="{Binding SettingsDiagnostics}">
+
+					<!-- Label -->
 					<TextBlock Text="SETTINGS"
 							   FontWeight="Bold"
 							   Margin="0,24,0,8" />
@@ -112,17 +123,20 @@
 							<ColumnDefinition Width="Auto" />
 						</Grid.ColumnDefinitions>
 
+						<!-- Label -->
 						<TextBlock Text="Diagnostics overlay"
 								   VerticalAlignment="Center" />
 
-						<ToggleSwitch HorizontalAlignment="Right"
+						<!-- ToggleSwitch -->
+						<ToggleSwitch IsOn="{Binding IsDiagnosticsOverlayEnabled, Mode=TwoWay}"
+									  HorizontalAlignment="Right"
 									  VerticalAlignment="Center"
 									  Width="50"
 									  MinWidth="50"
-									  IsOn="{Binding IsDiagnosticsOverlayEnabled, Mode=TwoWay}"
 									  Grid.Column="1" />
 					</Grid>
 
+					<!-- Open Settings Folder Button -->
 					<Button Content="Open settings folder"
 							Command="{Binding OpenSettingsFolder}"
 							Visibility="{Binding CanOpenSettingsFolder, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
@@ -132,6 +146,8 @@
 
 				<!-- Loggers -->
 				<StackPanel DataContext="{Binding LoggersDiagnostics}">
+					
+					<!-- Label -->
 					<TextBlock Text="LOGGERS"
 							   FontWeight="Bold"
 							   Margin="0,24,0,8" />
@@ -142,14 +158,15 @@
 							<ColumnDefinition Width="Auto" />
 						</Grid.ColumnDefinitions>
 
+						<!-- Label -->
 						<TextBlock Text="Console logging"
 								   VerticalAlignment="Center" />
 
-						<ToggleSwitch HorizontalAlignment="Right"
+						<!-- ToggleSwitch -->
+						<ToggleSwitch IsOn="{Binding IsConsoleLoggingEnabled, Mode=TwoWay}"
+									  HorizontalAlignment="Right"
 									  VerticalAlignment="Center"
 									  Width="50"
-									  MinWidth="50"
-									  IsOn="{Binding IsConsoleLoggingEnabled, Mode=TwoWay}"
 									  Grid.Column="1" />
 					</Grid>
 
@@ -159,70 +176,73 @@
 							<ColumnDefinition Width="Auto" />
 						</Grid.ColumnDefinitions>
 
-						<Grid.RowDefinitions>
-							<RowDefinition Height="Auto" />
-							<RowDefinition Height="Auto" />
-						</Grid.RowDefinitions>
-
+						<!-- File Logging Label -->
 						<TextBlock Text="File logging"
 								   VerticalAlignment="Center" />
 
-						<ToggleSwitch HorizontalAlignment="Right"
+						<!-- File Logging ToggleSwitch -->
+						<ToggleSwitch IsOn="{Binding IsFileLoggingEnabled, Mode=TwoWay}"
+									  HorizontalAlignment="Right"
 									  VerticalAlignment="Center"
 									  Width="50"
-									  MinWidth="50"
-									  IsOn="{Binding IsFileLoggingEnabled, Mode=TwoWay}"
 									  Grid.Column="1" />
-
-						<Button Content="Delete log files"
-								Command="{Binding DeleteLogFiles}"
-								Margin="0,4,0,0"
-								HorizontalAlignment="Stretch"
-								Grid.Row="1"
-								Grid.ColumnSpan="2" />
 					</Grid>
+						
+					<!-- Delete Log Files Button -->
+					<Button Content="Delete log files"
+							Command="{Binding DeleteLogFiles}"
+							HorizontalAlignment="Stretch"
+							Margin="0,4,0,0" />
 
+					<!-- Test Logs Button -->
 					<Button Content="Test logs of all levels"
 							Command="{Binding TestLogs}"
 							HorizontalAlignment="Stretch"
-							Margin="0,4" />
+							Margin="0,8" />
 				</StackPanel>
 
 				<!-- Error handling -->
 				<StackPanel DataContext="{Binding ExceptionDiagnostics}">
+
+					<!-- Label -->
 					<TextBlock Text="ERROR HANDLING"
 							   FontWeight="Bold"
 							   Margin="0,24,0,8" />
 
+					<!-- Test Error in Command Button -->
 					<Button Content="Test error in command"
+							Command="{Binding TestErrorInCommand}"
 							HorizontalAlignment="Stretch"
 							Padding="12"
-							Margin="0,4"
-							Command="{Binding TestErrorInCommand}" />
+							Margin="0,4" />
 
+					<!-- Test Error in Task Scheduler Button -->
 					<Button Content="Test error in task scheduler"
+							Command="{Binding TestErrorInTaskScheduler}"
 							HorizontalAlignment="Stretch"
 							Padding="12"
-							Margin="0,4"
-							Command="{Binding TestErrorInTaskScheduler}" />
+							Margin="0,4" />
 
+					<!-- Test Error in Core Dispatcher Button -->
 					<Button Content="Test error in core dispatcher"
+							Command="{Binding TestErrorInCoreDispatcher}"
 							HorizontalAlignment="Stretch"
 							Padding="12"
-							Margin="0,4"
-							Command="{Binding TestErrorInCoreDispatcher}" />
+							Margin="0,4" />
 
+					<!-- Test Error in Thread Pool Button -->
 					<Button Content="Test error in thread pool"
+							Command="{Binding TestErrorInThreadPool}"
 							HorizontalAlignment="Stretch"
 							Padding="12"
-							Margin="0,4"
-							Command="{Binding TestErrorInThreadPool}" />
+							Margin="0,4" />
 
+					<!-- Test Error in Main Thread Button -->
 					<Button Content="Test error in main thread"
+							Command="{Binding TestErrorInMainThread}"
 							HorizontalAlignment="Stretch"
 							Padding="12"
-							Margin="0,4"
-							Command="{Binding TestErrorInMainThread}" />
+							Margin="0,4" />
 				</StackPanel>
 			</StackPanel>
 		</ScrollViewer>

--- a/src/app/ApplicationTemplate.UWP/Views/Content/Welcome/OnboardingPage.xaml
+++ b/src/app/ApplicationTemplate.UWP/Views/Content/Welcome/OnboardingPage.xaml
@@ -85,8 +85,7 @@
 							  ItemsSource="{Binding OnboardingItems}"
 							  ItemTemplate="{StaticResource OnboardingItemTemplate}"
 							  IndexIndicatorTemplate="{StaticResource OnboardingIndexIndicatorTemplate}"
-							  SelectedIndexIndicatorTemplate="{StaticResource OnboardingSelectedIndexIndicatorTemplate}"
-							  Grid.Row="1" />
+							  SelectedIndexIndicatorTemplate="{StaticResource OnboardingSelectedIndexIndicatorTemplate}" />
 
 			<!-- Skip/Complete Button -->
 			<Button Content="{Binding ElementName=OnboardingSlideshow, Path=SelectedIndex, Converter={StaticResource SelectedIndexToButtonContent}}"

--- a/src/app/ApplicationTemplate.UWP/Views/Styles/Application/Brushes.xaml
+++ b/src/app/ApplicationTemplate.UWP/Views/Styles/Application/Brushes.xaml
@@ -17,6 +17,10 @@
 
 	<SolidColorBrush x:Key="MaterialPrimaryAccentBrush"
 					 Color="{ThemeResource MaterialPrimaryAccentColor}" />
+
+	<SolidColorBrush x:Key="MaterialPrimaryDarkBrush"
+					 Color="{ThemeResource MaterialPrimaryDarkColor}" />
+
 	
 	<SolidColorBrush x:Key="SeparatorBrush"
 					 Color="{ThemeResource MaterialOnSurfaceColor}"


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Feature

## Description

General clean up of the xaml file that include stuff like:
Added comments to organize code
Reorganize the order of properties in control in a more logical manner
Remove unnecessary blend using
Ensure proper use of material color resources
Reorganization of layout (like using stack panels instead of manually defines rows)
Make sure Margin and Padding are set using multiples of 4 (When it does not disturb design)
Removing property that use default values


## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] ~~Interface members are XML documented~~
- [ ] ~~Documentation (XML or comments) has been added and/or existing documentation has been updated~~
- [ ] ~~[Architecture documents](./doc/Architecture.md) have been updated~~
- [x] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
Clean up DiagnosticsPage.xaml
https://dev.azure.com/nventive/Practice%20committees/_workitems/edit/259227