### PR TITLE
feat: Clean up ResetPasswordPage.xaml

### DIFF
--- a/src/app/ApplicationTemplate.UWP/Views/Content/Authentication/ResetPasswordPage.xaml
+++ b/src/app/ApplicationTemplate.UWP/Views/Content/Authentication/ResetPasswordPage.xaml
@@ -2,22 +2,24 @@
 	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	  xmlns:local="using:ApplicationTemplate"
-	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:ue="using:Nventive.View.Extensions"
 	  xmlns:u="using:Nventive.View.Controls"
 	  xmlns:converters="using:ApplicationTemplate.Views"
 	  xmlns:android="http://nventive.com/android"
+	  xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:ios="http://nventive.com/ios"
 	  xmlns:toolkit="using:Uno.UI.Toolkit"
-	  mc:Ignorable="d android ios">
+	  mc:Ignorable="android ios">
 
 	<Page.Resources>
 		<ResourceDictionary>
+
+			<!-- Nullable Bool to IconStyle -->
 			<converters:FromNullableBoolToCustomValueConverter x:Key="NullableBoolToIconStyle"
-																DefaultValue="{StaticResource DarkCirclePathControlStyle}"
-																ValidValue="{StaticResource SuccessCheckPathControlStyle}"
-																InvalidValue="{StaticResource ErrorXPathControlStyle}" />
+															   DefaultValue="{StaticResource DarkCirclePathControlStyle}"
+															   ValidValue="{StaticResource SuccessCheckPathControlStyle}"
+															   InvalidValue="{StaticResource ErrorXPathControlStyle}" />
 		</ResourceDictionary>
 	</Page.Resources>
 
@@ -25,10 +27,7 @@
 
 		<!-- Background -->
 		<Image Source="{StaticResource BackgroundMustachesLightImage}"
-			   Stretch="UniformToFill"
-			   HorizontalAlignment="Stretch"
-			   VerticalAlignment="Stretch"
-			   Grid.RowSpan="2" />
+			   Stretch="UniformToFill" />
 
 		<Grid toolkit:VisibleBoundsPadding.PaddingMask="Top,Bottom">
 			<Grid.RowDefinitions>
@@ -36,36 +35,34 @@
 				<RowDefinition Height="*" />
 			</Grid.RowDefinitions>
 
+			<!-- CommandBar -->
 			<CommandBar Style="{StaticResource TransparentCommandBarStyle}"
-						toolkit:CommandBarExtensions.BackButtonForeground="{StaticResource MaterialOnSurfaceBrush}" />
+						toolkit:CommandBarExtensions.BackButtonForeground="{StaticResource MaterialOnBackgroundBrush}" />
 
 			<ScrollViewer Grid.Row="1">
-				<StackPanel VerticalAlignment="Center">
+				<StackPanel VerticalAlignment="Center"
+							Margin="44,0">
 
 					<!-- Title -->
 					<TextBlock Text="Reset password"
 							   x:Uid="ResetPassword_Title"
-							   Margin="22,0"
 							   Style="{StaticResource Headline3}"
-							   Foreground="{StaticResource MaterialOnSurfaceBrush}"
-							   HorizontalTextAlignment="Center"
-							   HorizontalAlignment="Center" />
+							   Foreground="{StaticResource MaterialOnBackgroundBrush}"
+							   TextAlignment="Center" />
 
 					<!-- Subtitle -->
 					<TextBlock Text="Welcome back, choose a new password that you can easily remember."
 							   x:Uid="ResetPassword_Subtitle"
 							   Style="{StaticResource Body1}"
-							   Foreground="{StaticResource MaterialOnSurfaceBrush}"
-							   Margin="22,16,22,32"
+							   Foreground="{StaticResource MaterialOnBackgroundBrush}"
+							   TextAlignment="Center"
 						       MaxWidth="370"
-							   HorizontalTextAlignment="Center"
-							   HorizontalAlignment="Center" />
+							   Margin="0,16,0,0" />
 
 					<!-- Password -->
-					<local:DataValidationView Model="{Binding PasswordForm}"
-											  PropertyName="Password"
-											  Margin="42,12,42,4"
-											  Background="{StaticResource MaterialSurfaceBrush}">
+					<local:DataValidationView PropertyName="Password"
+											  Model="{Binding PasswordForm}"
+											  Margin="0,44,0,0">
 						<PasswordBox x:Name="PasswordField"
 									 x:Uid="ResetPassword_Password"
 									 PlaceholderText="Choose a new password"
@@ -75,68 +72,82 @@
 									 ue:PasswordBoxBehavior.DismissKeyboardOnEnter="True" />
 					</local:DataValidationView>
 
-					<!-- Password Validation Hints -->
-					<Grid Margin="42,0">
-						<Grid.RowDefinitions>
-							<RowDefinition Height="Auto" />
-							<RowDefinition Height="Auto" />
-							<RowDefinition Height="Auto" />
-						</Grid.RowDefinitions>
+					<!--
+						Password Validation Hints
+					-->
 
-						<Grid.ColumnDefinitions>
-							<ColumnDefinition Width="Auto" />
-							<ColumnDefinition Width="*" />
-						</Grid.ColumnDefinitions>
-
+					<!-- 8 Characters Minimum Check -->
+					<StackPanel Orientation="Horizontal"
+								MinHeight="15"
+								Margin="0,8,0,0">
+						
+						<!-- Check -->
 						<u:PathControl x:Name="HasMinLengthPathControl"
-									   VerticalAlignment="Center"
 									   Style="{Binding PasswordForm.PasswordHasMinimumLength, Converter={StaticResource NullableBoolToIconStyle}}"
-									   Margin="9,4,9,4" />
+									   Width="15"
+									   VerticalAlignment="Center" />
 
-						<u:PathControl x:Name="HasNumberPathControl"
-									   Style="{Binding PasswordForm.PasswordHasNumber, Converter={StaticResource NullableBoolToIconStyle}}"
-									   VerticalAlignment="Center"
-									   Grid.Row="1"
-									   Margin="9,4,9,4" />
-
-						<u:PathControl x:Name="HasUppercasePathControl"
-									   Style="{Binding PasswordForm.PasswordHasUppercase, Converter={StaticResource NullableBoolToIconStyle}}"
-									   VerticalAlignment="Center"
-									   Grid.Row="2"
-									   Margin="9,4,9,4" />
-
+						<!-- Hint -->
 						<TextBlock x:Name="HasMinimumLengthText"
 								   Text="8 characters minimum"
 								   x:Uid="Password_Validation1"
-								   Grid.Column="1"
-								   Margin="0,4,0,4"
 								   Style="{StaticResource Body3}"
-								   Foreground="{StaticResource MaterialOnBackgroundBrush}" />
+								   Foreground="{StaticResource MaterialOnBackgroundBrush}"
+								   VerticalAlignment="Center"
+								   android:Margin="8,0,0,0"
+								   not_android:Margin="8,3,0,0"/>
+					</StackPanel>
 
+					<!-- Has Number Hint -->
+					<StackPanel Orientation="Horizontal"
+								MinHeight="15"
+								Margin="0,4,0,0">
+						
+						<!-- Check -->
+						<u:PathControl x:Name="HasNumberPathControl"
+									   Style="{Binding PasswordForm.PasswordHasNumber, Converter={StaticResource NullableBoolToIconStyle}}"
+									   Width="15"
+									   VerticalAlignment="Center" />
+
+						<!-- Hint -->
 						<TextBlock x:Name="HasNumberText"
 								   Text="One number"
 								   x:Uid="Password_Validation2"
-								   Grid.Column="1"
-								   Grid.Row="1"
-								   Margin="0,4,0,4"
 								   Style="{StaticResource Body3}"
-								   Foreground="{StaticResource MaterialOnBackgroundBrush}" />
+								   Foreground="{StaticResource MaterialOnBackgroundBrush}"
+								   VerticalAlignment="Center"
+								   android:Margin="8,0,0,0"
+								   not_android:Margin="8,3,0,0"/>
+					</StackPanel>
 
+					<!-- Has Uppercase Hint -->
+					<StackPanel Orientation="Horizontal"
+								MinHeight="15"
+								Margin="0,4,0,0">
+
+						<!-- Check -->
+						<u:PathControl x:Name="HasUppercasePathControl"
+									   Style="{Binding PasswordForm.PasswordHasUppercase, Converter={StaticResource NullableBoolToIconStyle}}"
+									   Width="15"
+									   VerticalAlignment="Center" />
+
+						<!-- Hint -->
 						<TextBlock x:Name="HasUppercaseText"
 								   Text="One uppercase character"
 								   x:Uid="Password_Validation3"
-								   Grid.Column="1"
-								   Grid.Row="2"
-								   Margin="0,4,0,4"
 								   Style="{StaticResource Body3}"
-								   Foreground="{StaticResource MaterialOnBackgroundBrush}" />
-					</Grid>
+								   Foreground="{StaticResource MaterialOnBackgroundBrush}"
+								   VerticalAlignment="Center"
+								   android:Margin="8,0,0,0"
+								   not_android:Margin="8,3,0,0"/>
+					</StackPanel>
 
-					<Button Command="{Binding ConfirmReset}"
-						x:Uid="ResetPassword_Reset"
-						Content="SAVE MY PASSWORD"
-						HorizontalAlignment="Stretch"
-						Margin="42,32" />
+					<!-- Save Password Button -->
+					<Button Content="SAVE MY PASSWORD"
+							x:Uid="ResetPassword_Reset"
+							Command="{Binding ConfirmReset}"
+							HorizontalAlignment="Stretch"
+							Margin="0,32" />
 				</StackPanel>
 			</ScrollViewer>
 		</Grid>


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Feature

## Description

General clean up of the xaml file that include stuff like: 
Added comments to organize code
Reorganize the order of properties in control in a more logical manner 
Remove unecessary blend using
Ensure proper use of material color ressources
Reorganization of layout (like using stack panels instead of mannually defines rows)
Make sure Margin and Padding are set using multiples of 4 (When it does not disturb design)


## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] ~~Interface members are XML documented~~
- [ ] ~~Documentation (XML or comments) has been added and/or existing documentation has been updated~~
- [ ] ~~[Architecture documents](./doc/Architecture.md) have been updated~~
- [x] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
Clean up ResetPasswordPage.xaml
[TODO](https://dev.azure.com/nventive/Practice%20committees/_workitems/edit/259217)