### PR TITLE
fix: android and ios variable group now correct

### DIFF
--- a/.azure-pipelines-canary.yml
+++ b/.azure-pipelines-canary.yml
@@ -21,10 +21,10 @@ stages:
     parameters:
       applicationEnvironment: Staging
       androidKeyStoreFile: $(InternalKeystore)
-      androidVariableGroup: 'ApplicationTemplate.Internal.Android'
+      androidVariableGroup: 'ApplicationTemplate.Distribution.Internal.Android'
       iosProvisioningProfileFile: $(InternalProvisioningProfile)
       iosCertificateFile: $(InternalCertificate)
-      iosVariableGroup: 'ApplicationTemplate.Internal.iOS'
+      iosVariableGroup: 'ApplicationTemplate.Distribution.Internal.iOS'
       removeHyperlinksFromReleaseNotes: true
 
 - stage: AppCenter_Canary
@@ -40,6 +40,6 @@ stages:
       appCenteriOSSlug: $(AppCenteriOSSlug_Canary)
       appCenterAndroidSlug: $(AppCenterAndroidSlug_Canary)
       androidKeyStoreFile: $(InternalKeystore)
-      androidVariableGroup: 'ApplicationTemplate.Internal.Android'
+      androidVariableGroup: 'ApplicationTemplate.Distribution.Internal.Android'
       appCenterServiceConnectionName: $(AppCenterCanaryServiceConnection)
       appCenterDistributionGroup: $(AppCenterCanaryDistributionGroup)


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## Description
updated canary xaml to point to the correct andriod/iOSVariableGroup


## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [ ] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [ ] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->