### PR TITLE
fix: Canary pipelines failing due to MessageDialogBuilderDelegate

### DIFF
--- a/src/app/ApplicationTemplate.Droid/ApplicationTemplate.Droid.csproj
+++ b/src/app/ApplicationTemplate.Droid/ApplicationTemplate.Droid.csproj
@@ -103,7 +103,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MessageDialogService.Uno" Version="0.5.0-dev.14" />
+    <PackageReference Include="MessageDialogService.Uno" Version="0.5.0-dev.48" />
     <PackageReference Include="Uno.Toolkit.UI" Version="1.4.0-dev.16" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.1.0" />
     <PackageReference Include="Xamarin.Build.Download" Version="0.10.0" />

--- a/src/app/ApplicationTemplate.Shared.Views/Configuration/ViewServicesConfiguration.cs
+++ b/src/app/ApplicationTemplate.Shared.Views/Configuration/ViewServicesConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using System.Reactive.Concurrency;
+﻿using System;
+using System.Reactive.Concurrency;
 using Chinook.DynamicMvvm;
 using MessageDialogService;
 using Microsoft.Extensions.DependencyInjection;
@@ -40,7 +41,8 @@ public static class ViewServicesConfiguration
 			new MessageDialogService.MessageDialogService(
 				() => s.GetRequiredService<CoreDispatcher>(),
 				new MessageDialogBuilderDelegate(
-					key => s.GetRequiredService<IStringLocalizer>()[key]
+					key => s.GetRequiredService<IStringLocalizer>()[key],
+					windowHandle: null
 				)
 			)
 //-:cnd:noEmit

--- a/src/app/ApplicationTemplate.Shared.Views/Configuration/ViewServicesConfiguration.cs
+++ b/src/app/ApplicationTemplate.Shared.Views/Configuration/ViewServicesConfiguration.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reactive.Concurrency;
+﻿using System.Reactive.Concurrency;
 using Chinook.DynamicMvvm;
 using MessageDialogService;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/app/ApplicationTemplate.UWP/ApplicationTemplate.UWP.csproj
+++ b/src/app/ApplicationTemplate.UWP/ApplicationTemplate.UWP.csproj
@@ -179,7 +179,7 @@
     <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />
     <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
-    <PackageReference Include="MessageDialogService.Uno" Version="0.5.0-dev.14" />
+    <PackageReference Include="MessageDialogService.Uno" Version="0.5.0-dev.48" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.13" />
     <PackageReference Include="Uno.Toolkit.UI" Version="1.4.0-dev.16" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />

--- a/src/app/ApplicationTemplate.iOS/ApplicationTemplate.iOS.csproj
+++ b/src/app/ApplicationTemplate.iOS/ApplicationTemplate.iOS.csproj
@@ -122,7 +122,7 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MessageDialogService.Uno" Version="0.5.0-dev.14" />
+    <PackageReference Include="MessageDialogService.Uno" Version="0.5.0-dev.48" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="Uno.Toolkit.UI" Version="1.4.0-dev.16" />
     <PackageReference Include="Xamarin.Build.Download" Version="0.10.0" />


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
- Build or CI related changes


## Description
Canary was returning _There is no argument given that corresponds to the required formal parameter 'windowHandle' of 'MessageDialogBuilderDelegate.MessageDialogBuilderDelegate(Func<string, string>, IntPtr?)'_ error due to missing windowHandle in AddMessageDialog. Updated to MessageDialogService.Uno to v0.5.0-dev.48 and added a null windowHandle to AddMessageDialog

## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [ ] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [x] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->