### PR TITLE
ci: remove unecessary msbuild args

### DIFF
--- a/build/build-ios.sh
+++ b/build/build-ios.sh
@@ -3,6 +3,4 @@
 #$2 Configuration
 #$3 Platform
 #$4 Provisioning Profile UUID
-#$5 Application identifier
-#$6 Package Version
-/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono "/Applications/Visual Studio.app/Contents/MonoBundle/MSBuild/Current/bin/MSBuild.dll" /t:Build "$1" /p:Configuration="$2" /p:Platform="$3" /p:buildForSimulator=false /p:BuildIpa=true /p:CodesignProvision="$4" /p:ApplicationIdentifier="$5" /p:PackageVersion="$6" /bl
+/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono "/Applications/Visual Studio.app/Contents/MonoBundle/MSBuild/Current/bin/MSBuild.dll" /t:Build "$1" /p:Configuration="$2" /p:Platform="$3" /p:buildForSimulator=false /p:BuildIpa=true /p:CodesignProvision="$4" /bl

--- a/build/steps-build.yml
+++ b/build/steps-build.yml
@@ -125,10 +125,7 @@ steps:
     msbuildVersion: latest
     msbuildArchitecture: x86
     msbuildArguments: >
-      /p:PackageVersion=$(PreReleaseNumber)
-      /p:ApplicationBuildNumber=$(PreReleaseNumber)
       /p:ApplicationEnvironment=$(ApplicationEnvironment)
-      /p:ApplicationVersion=$(MajorMinorPatch)
       /p:AndroidBuildApplicationPackage=true
       /p:AndroidSigningKeyStore=$(keyStore.secureFilePath)
       /p:AndroidSigningStorePass=$(AndroidSigningStorePass)
@@ -136,7 +133,6 @@ steps:
       /p:AndroidSigningKeyAlias=$(AndroidSigningKeyAlias)
       /p:AndroidKeyStore=true
       /p:CodesignProvision=$(provisioningProfile.provisioningProfileUuid)
-      /p:ApplicationIdentifier=$(ApplicationIdentifier)
       /p:IsLightBuild=$(IsLightBuild) 
       /bl
     configuration: $(ApplicationConfiguration)
@@ -154,7 +150,7 @@ steps:
   condition: and(succeeded(), not(eq('${{ parameters.iosProvisioningProfileFile }}', '')))
   inputs:
     filePath: '$(System.DefaultWorkingDirectory)/build/build-ios.sh'
-    arguments: '"${{ parameters.pathToSrc }}/${{ parameters.solutionFileName }}" "$(ApplicationConfiguration)" "$(ApplicationPlatform)" "$(provisioningProfile.provisioningProfileUuid)" "$(ApplicationIdentifier)" "$(PreReleaseNumber)"'
+    arguments: '"${{ parameters.pathToSrc }}/${{ parameters.solutionFileName }}" "$(ApplicationConfiguration)" "$(ApplicationPlatform)" "$(provisioningProfile.provisioningProfileUuid)"'
 
 - script: >
     dotnet test ${{ parameters.pathToSrc }}/${{ parameters.solutionFileName }}


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Build or CI related changes


## Description

- Remove unecessary `msbuild `arguments that were previously used with old pipelines. Now those arguments are not needed anymore as we make usage of tasks to update `AppIdentifier`, `AppVersion` etc for both `iOS` and `Android `

<!-- (Please describe the changes that this PR introduces.) -->


## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [ ] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [ ] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->