### PR TITLE
fix: Improve Uno.Material usage

### DIFF
--- a/src/app/ApplicationTemplate.Shared.Views/Content/Diagnostics/DiagnosticsPage.xaml
+++ b/src/app/ApplicationTemplate.Shared.Views/Content/Diagnostics/DiagnosticsPage.xaml
@@ -66,7 +66,7 @@
 							   Margin="0,24,0,8" />
 
 					<!-- Value -->
-					<Border Background="{StaticResource MaterialPrimaryDarkBrush}"
+					<Border Background="{StaticResource MaterialPrimaryVariantDarkBrush}"
 							Padding="8,4">
 						<TextBlock Text="{Binding Summary}"
 								   FontSize="11"

--- a/src/app/ApplicationTemplate.Shared.Views/Content/Settings/SettingsPage.xaml
+++ b/src/app/ApplicationTemplate.Shared.Views/Content/Settings/SettingsPage.xaml
@@ -201,7 +201,7 @@
 				<Button Content="LOGOUT"
 						x:Uid="Settings_Logout"
 						Command="{Binding Logout}"
-						Background="{StaticResource MaterialPrimaryAccentBrush}"
+						Background="{StaticResource PrimaryAccentBrush}"
 						HorizontalAlignment="Left"
 						Margin="24,16" />
 			</StackPanel>

--- a/src/app/ApplicationTemplate.Shared.Views/Styles/Application/Brushes.xaml
+++ b/src/app/ApplicationTemplate.Shared.Views/Styles/Application/Brushes.xaml
@@ -5,17 +5,13 @@
 	<x:Int32 x:Key="BrushesWorkaround">0</x:Int32>
 
 	<!-- Success brushes -->
-	<SolidColorBrush x:Key="MaterialSuccessBrush"
-					 Color="{ThemeResource MaterialSuccessColor}" />
-	<SolidColorBrush x:Key="MaterialOnSuccessBrush"
-					 Color="{ThemeResource MaterialOnSuccessColor}" />
+	<SolidColorBrush x:Key="SuccessBrush"
+					 Color="{ThemeResource SuccessColor}" />
+	<SolidColorBrush x:Key="OnSuccessBrush"
+					 Color="{ThemeResource OnSuccessColor}" />
 
-	<SolidColorBrush x:Key="MaterialPrimaryAccentBrush"
-					 Color="{ThemeResource MaterialPrimaryAccentColor}" />
-
-	<SolidColorBrush x:Key="MaterialPrimaryDarkBrush"
-					 Color="{ThemeResource MaterialPrimaryDarkColor}" />
-
+	<SolidColorBrush x:Key="PrimaryAccentBrush"
+					 Color="{ThemeResource PrimaryAccentColor}" />
 	
 	<SolidColorBrush x:Key="SeparatorBrush"
 					 Color="{ThemeResource MaterialOnSurfaceColor}"

--- a/src/app/ApplicationTemplate.Shared.Views/Styles/Application/ColorPalette.xaml
+++ b/src/app/ApplicationTemplate.Shared.Views/Styles/Application/ColorPalette.xaml
@@ -6,6 +6,16 @@
 
 	<ResourceDictionary.ThemeDictionaries>
 		<ResourceDictionary x:Key="Light">
+			<Color x:Key="PrimaryAccentColor">#F9423A</Color>
+
+			<Color x:Key="SuccessColor">#59DF9F</Color>
+			<Color x:Key="OnSuccessColor">#105132</Color>
+		</ResourceDictionary>
+		<ResourceDictionary x:Key="Dark">
+			<Color x:Key="PrimaryAccentColor">#F9423A</Color>
+
+			<Color x:Key="SuccessColor">#105132</Color>
+			<Color x:Key="OnSuccessColor">#9BECC5</Color>
 		</ResourceDictionary>
 	</ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/src/app/ApplicationTemplate.Shared.Views/Styles/Application/MaterialOverride.xaml
+++ b/src/app/ApplicationTemplate.Shared.Views/Styles/Application/MaterialOverride.xaml
@@ -14,14 +14,13 @@
 		<ResourceDictionary x:Key="Light">
 			<Color x:Key="MaterialPrimaryColor">#0D59CD</Color>
 			<Color x:Key="MaterialOnPrimaryColor">#FFFFFF</Color>
-			<Color x:Key="MaterialPrimaryDarkColor">#0A447D</Color>
-			<Color x:Key="MaterialPrimaryLightColor">#0A68C8</Color>
-			<Color x:Key="MaterialPrimaryAccentColor">#F9423A</Color>
+			<Color x:Key="MaterialPrimaryVariantDarkColor">#0A447D</Color>
+			<Color x:Key="MaterialPrimaryVariantLightColor">#0A68C8</Color>
 
 			<Color x:Key="MaterialSecondaryColor">#5BC5F2</Color>
 			<Color x:Key="MaterialOnSecondaryColor">#001E60</Color>
-			<Color x:Key="MaterialSecondaryDarkColor">#4FB0D2</Color>
-			<Color x:Key="MaterialSecondaryLightColor">#68D2F8</Color>
+			<Color x:Key="MaterialSecondaryVariantDarkColor">#4FB0D2</Color>
+			<Color x:Key="MaterialSecondaryVariantLightColor">#68D2F8</Color>
 
 			<Color x:Key="MaterialBackgroundColor">#F5FAFF</Color>
 			<Color x:Key="MaterialOnBackgroundColor">#001E60</Color>
@@ -31,21 +30,18 @@
 
 			<Color x:Key="MaterialErrorColor">#D93B27</Color>
 			<Color x:Key="MaterialOnErrorColor">#FDEFED</Color>
-			<Color x:Key="MaterialSuccessColor">#59DF9F</Color>
-			<Color x:Key="MaterialOnSuccessColor">#105132</Color>
 		</ResourceDictionary>
 
 		<ResourceDictionary x:Key="Dark">
 			<Color x:Key="MaterialPrimaryColor">#89C5FF</Color>
 			<Color x:Key="MaterialOnPrimaryColor">#121821</Color>
-			<Color x:Key="MaterialPrimaryDarkColor">#4FA1F0</Color>
-			<Color x:Key="MaterialPrimaryLightColor">#AED7FF</Color>
-			<Color x:Key="MaterialPrimaryAccentColor">#F9423A</Color>
+			<Color x:Key="MaterialPrimaryVariantDarkColor">#4FA1F0</Color>
+			<Color x:Key="MaterialPrimaryVariantLightColor">#AED7FF</Color>
 
 			<Color x:Key="MaterialSecondaryColor">#FCA58B</Color>
 			<Color x:Key="MaterialOnSecondaryColor">#302B29</Color>
-			<Color x:Key="MaterialSecondaryDarkColor">#FA825D</Color>
-			<Color x:Key="MaterialSecondaryLightColor">#FDC9B8</Color>
+			<Color x:Key="MaterialSecondaryVariantDarkColor">#FA825D</Color>
+			<Color x:Key="MaterialSecondaryVariantLightColor">#FDC9B8</Color>
 
 			<Color x:Key="MaterialBackgroundColor">#1C2025</Color>
 			<Color x:Key="MaterialOnBackgroundColor">#FFF</Color>
@@ -55,8 +51,6 @@
 
 			<Color x:Key="MaterialErrorColor">#E8897D</Color>
 			<Color x:Key="MaterialOnErrorColor">#32110D</Color>
-			<Color x:Key="MaterialSuccessColor">#105132</Color>
-			<Color x:Key="MaterialOnSuccessColor">#9BECC5</Color>
 		</ResourceDictionary>
 	</ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/src/app/ApplicationTemplate.Shared.Views/Styles/Controls/PathControl.xaml
+++ b/src/app/ApplicationTemplate.Shared.Views/Styles/Controls/PathControl.xaml
@@ -62,7 +62,7 @@
 	<Style x:Key="SuccessCheckPathControlStyle"
 		   TargetType="u:PathControl">
 		<Setter Property="Foreground"
-				Value="{StaticResource MaterialSuccessBrush}" />
+				Value="{StaticResource SuccessBrush}" />
 		<Setter Property="Stretch"
 				Value="Uniform" />
 		<Setter Property="Height"


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

## Description

<!-- (Please describe the changes that this PR introduces.) -->

- Move non-material colors to ColorPalette.xaml.
- Use correct name for light and dark variants of Material primary and secondary.
- Remove the word "Material" from non-Material resources.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [ ] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [x] Tested on all relevant platforms
