### PR TITLE
feat: Leverage `DataLoaderView.DefaultRefreshCommandProvider`

### DIFF
--- a/src/app/ApplicationTemplate.Mobile/ApplicationTemplate.Mobile.csproj
+++ b/src/app/ApplicationTemplate.Mobile/ApplicationTemplate.Mobile.csproj
@@ -10,10 +10,11 @@
 		<UseMauiEssentials>true</UseMauiEssentials>
 		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-android'">26.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-ios'">14.2</SupportedOSPlatformVersion>
+		<NoWarn>Uno0001</NoWarn>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Chinook.BackButtonManager.Uno.WinUI" Version="1.1.2" />
-		<PackageReference Include="Chinook.DataLoader.Uno.WinUI" Version="1.1.0" />
+		<PackageReference Include="Chinook.DataLoader.Uno.WinUI" Version="1.2.0" />
 		<PackageReference Include="Chinook.DynamicMvvm.Uno.WinUI" Version="1.1.2" />
 		<PackageReference Include="Chinook.SectionsNavigation.Uno.WinUI" Version="1.1.2" />
 		<PackageReference Include="ExtendedSplashScreen.Uno.WinUI" Version="0.3.0-dev.51" />

--- a/src/app/ApplicationTemplate.Presentation/ApplicationTemplate.Presentation.csproj
+++ b/src/app/ApplicationTemplate.Presentation/ApplicationTemplate.Presentation.csproj
@@ -27,7 +27,7 @@
 		<PackageReference Include="Chinook.DynamicMvvm.Reactive" Version="1.1.2" />
 		<PackageReference Include="Chinook.DynamicMvvm.FluentValidation" Version="1.1.2" />
 		<PackageReference Include="Chinook.DynamicMvvm.CollectionTracking" Version="1.1.2" />
-		<PackageReference Include="Chinook.DataLoader" Version="1.1.0" />
+		<PackageReference Include="Chinook.DataLoader" Version="1.2.0" />
 		<PackageReference Include="Chinook.DataLoader.DynamicMvvm" Version="1.1.0" />
 		<PackageReference Include="Chinook.BackButtonManager" Version="1.1.2" />
 		<PackageReference Include="Chinook.SectionsNavigation" Version="1.1.2" />

--- a/src/app/ApplicationTemplate.Presentation/ViewModels/DadJokes/DadJokesPageViewModel.cs
+++ b/src/app/ApplicationTemplate.Presentation/ViewModels/DadJokes/DadJokesPageViewModel.cs
@@ -19,8 +19,6 @@ public partial class DadJokesPageViewModel : ViewModel
 		await this.GetService<ISectionsNavigator>().Navigate(ct, () => new DadJokesFiltersPageViewModel());
 	});
 
-	public IDynamicCommand RefreshJokes => this.GetCommandFromDataLoaderRefresh(Jokes);
-
 	public IDataLoader<DadJokesItemViewModel[]> Jokes => this.GetDataLoader(LoadJokes, b => b
 		// Dispose the previous ItemViewModels when Quotes produces new values.
 		.DisposePreviousData()

--- a/src/app/ApplicationTemplate.Presentation/ViewModels/Posts/PostsPageViewModel.cs
+++ b/src/app/ApplicationTemplate.Presentation/ViewModels/Posts/PostsPageViewModel.cs
@@ -35,8 +35,6 @@ public partial class PostsPageViewModel : ViewModel
 		await this.GetService<IStackNavigator>().Navigate(ct, () => new EditPostPageViewModel(post));
 	});
 
-	public IDynamicCommand RefreshPosts => this.GetCommandFromDataLoaderRefresh(Posts);
-
 	public IDataLoader Posts => this.GetDataLoader(GetPosts, d => d.WithTrigger(_deletePostTrigger));
 
 	private async Task<ImmutableList<Post>> GetPosts(CancellationToken ct)

--- a/src/app/ApplicationTemplate.Shared.Views/Content/DadJokes/DadJokesPage.xaml
+++ b/src/app/ApplicationTemplate.Shared.Views/Content/DadJokes/DadJokesPage.xaml
@@ -52,16 +52,16 @@
 		</CommandBar>
 
 		<!-- DataLoaderView -->
-		<dl:DataLoaderView Source="{Binding Jokes}"
-						   RefreshCommand="{Binding RefreshJokes}"
+		<dl:DataLoaderView x:Name="JokesDataLoader"
+						   Source="{Binding Jokes}"
 						   EmptyTemplate="{StaticResource JokesEmptyTemplate}"
 						   Grid.Row="1">
 			<DataTemplate>
 
 				<!-- SwipeRefresh -->
 				<u:SwipeRefresh x:Name="RefreshContent"
-								RefreshCommand="{Binding Parent.RefreshJokes}"
-								IsRefreshing="{Binding Parent.RefreshJokes.IsExecuting}"
+								RefreshCommand="{Binding ElementName=JokesDataLoader, Path=RefreshCommand}"
+								IsRefreshing="{Binding ElementName=JokesDataLoader, Path=RefreshCommand.IsExecuting}"
 								IndicatorColor="{StaticResource MaterialPrimaryBrush}">
 
 					<!-- Jokes ListView -->

--- a/src/app/ApplicationTemplate.Shared.Views/Content/Posts/PostsPage.xaml
+++ b/src/app/ApplicationTemplate.Shared.Views/Content/Posts/PostsPage.xaml
@@ -19,14 +19,14 @@
 		<Grid Grid.Row="1">
 
 			<!-- DataLoader View -->
-			<dl:DataLoaderView Source="{Binding Posts}"
-							   RefreshCommand="{Binding RefreshPosts}">
+			<dl:DataLoaderView x:Name="PostsDataLoaderView"
+							   Source="{Binding Posts}">
 				<DataTemplate>
 
 					<!-- Swipe to Refresh -->
 					<u:SwipeRefresh x:Name="RefreshContent"
-									RefreshCommand="{Binding Parent.RefreshPosts}"
-									IsRefreshing="{Binding Parent.RefreshPosts.IsExecuting}"
+									RefreshCommand="{Binding ElementName=PostsDataLoaderView, Path=RefreshCommand}"
+									IsRefreshing="{Binding ElementName=PostsDataLoaderView, Path=RefreshCommand.IsExecuting}"
 									IndicatorColor="{StaticResource MaterialPrimaryBrush}">
 
 						<!-- ListView -->

--- a/src/app/ApplicationTemplate.Windows/ApplicationTemplate.Windows.csproj
+++ b/src/app/ApplicationTemplate.Windows/ApplicationTemplate.Windows.csproj
@@ -31,7 +31,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Chinook.BackButtonManager.Uno.WinUI" Version="1.1.2" />
-		<PackageReference Include="Chinook.DataLoader.Uno.WinUI" Version="1.1.0" />
+		<PackageReference Include="Chinook.DataLoader.Uno.WinUI" Version="1.2.0" />
 		<PackageReference Include="Chinook.DynamicMvvm.Uno.WinUI" Version="1.1.2" />
 		<PackageReference Include="Chinook.SectionsNavigation.Uno.WinUI" Version="1.1.2" />
 		<PackageReference Include="ExtendedSplashScreen.Uno.WinUI" Version="0.3.0-dev.51" />


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Feature

## Description

<!-- (Please describe the changes that this PR introduces.) -->

- Update the Chinook.DataLoader packages to leverage `DataLoaderView.DefaultRefreshCommandProvider`.
  - This allows to configure a default refresh command that applies to any `DataLoaderView`.
  - This allows to reduce the code in ViewModels that use IDataLoader because they no longer need to create a RefreshCommand per DataLoader.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [x] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [x] Tested on all relevant platforms