### PR TITLE
fix: Use proper visual for Android 12+ extended splash screen.

### DIFF
--- a/src/app/ApplicationTemplate.Mobile/Android/MainActivity.Android.cs
+++ b/src/app/ApplicationTemplate.Mobile/Android/MainActivity.Android.cs
@@ -1,5 +1,6 @@
 ﻿using Android.App;
 using Android.Content.PM;
+using Android.OS;
 using Android.Views;
 
 namespace ApplicationTemplate;
@@ -14,4 +15,11 @@ namespace ApplicationTemplate;
 )]
 public sealed class MainActivity : Microsoft.UI.Xaml.ApplicationActivity
 {
+	protected override void OnCreate(Bundle bundle)
+	{
+		// Support the ExtendedSplashScreen on Android 12+.
+		Nventive.ExtendedSplashScreen.ExtendedSplashScreen.AndroidSplashScreen = AndroidX.Core.SplashScreen.SplashScreen.InstallSplashScreen(this);
+
+		base.OnCreate(bundle);
+	}
 }

--- a/src/app/ApplicationTemplate.Mobile/ApplicationTemplate.Mobile.csproj
+++ b/src/app/ApplicationTemplate.Mobile/ApplicationTemplate.Mobile.csproj
@@ -17,7 +17,7 @@
 		<PackageReference Include="Chinook.DataLoader.Uno.WinUI" Version="1.2.0" />
 		<PackageReference Include="Chinook.DynamicMvvm.Uno.WinUI" Version="1.1.2" />
 		<PackageReference Include="Chinook.SectionsNavigation.Uno.WinUI" Version="1.1.2" />
-		<PackageReference Include="ExtendedSplashScreen.Uno.WinUI" Version="0.3.0-dev.51" />
+		<PackageReference Include="ExtendedSplashScreen.Uno.WinUI" Version="0.5.0-dev.60" />
 		<PackageReference Include="MessageDialogService.Uno.WinUI" Version="0.6.0-dev.58" />
 		<PackageReference Include="Nventive.Persistence.Uno.WinUI" Version="0.4.0-dev.36" />
 		<PackageReference Include="Nventive.View.Uno.WinUI" Version="0.5.0-dev.62" />
@@ -98,6 +98,7 @@
 				<PackageReference Include="Xamarin.Google.Android.Material" Version="1.7.0.1" />
 				<PackageReference Include="Uno.UniversalImageLoader" Version="1.9.36" />
 				<PackageReference Include="Mono.AotProfiler.Android" Version="6.0.0" />
+				<PackageReference Include="Xamarin.Kotlin.StdLib.Jdk8" Version="1.8.0" />
 			</ItemGroup>
 			<ItemGroup>
 				<AndroidAotProfile Include="custom.aprof" />

--- a/src/app/ApplicationTemplate.Windows/ApplicationTemplate.Windows.csproj
+++ b/src/app/ApplicationTemplate.Windows/ApplicationTemplate.Windows.csproj
@@ -34,7 +34,7 @@
 		<PackageReference Include="Chinook.DataLoader.Uno.WinUI" Version="1.2.0" />
 		<PackageReference Include="Chinook.DynamicMvvm.Uno.WinUI" Version="1.1.2" />
 		<PackageReference Include="Chinook.SectionsNavigation.Uno.WinUI" Version="1.1.2" />
-		<PackageReference Include="ExtendedSplashScreen.Uno.WinUI" Version="0.3.0-dev.51" />
+		<PackageReference Include="ExtendedSplashScreen.Uno.WinUI" Version="0.5.0-dev.60" />
 		<PackageReference Include="MessageDialogService.Uno.WinUI" Version="0.6.0-dev.58" />
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.3" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.196" />


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

## Description

<!-- (Please describe the changes that this PR introduces.) -->

Update ExtendedSplashScreen packages to support the Android 12+ visuals.

### Before and After
In the following videos, the ExtendedSplashScreen is when we see a loading wheel.

#### Before
https://user-images.githubusercontent.com/39710855/221656890-82cd638b-af33-4716-be59-4d627be7ec2e.mp4

#### After
https://user-images.githubusercontent.com/39710855/221656902-32b45c45-524e-447c-9120-0c677914a8ed.mp4

## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [ ] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [x] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->