### PR TITLE
fix: don't call extendedsplashscreen android 12 specific code for android 11 and lower

### DIFF
--- a/src/app/ApplicationTemplate.Mobile/Android/Main.Android.cs
+++ b/src/app/ApplicationTemplate.Mobile/Android/Main.Android.cs
@@ -10,7 +10,7 @@ namespace ApplicationTemplate.Droid;
 	Icon = "@mipmap/ic_launcher",
 	LargeHeap = true,
 	HardwareAccelerated = true,
-	Theme = "@style/AppTheme",
+	Theme = "@style/AppTheme.Starting",
 	AllowBackup = false,
 	ResizeableActivity = false
 )]

--- a/src/app/ApplicationTemplate.Mobile/Android/MainActivity.Android.cs
+++ b/src/app/ApplicationTemplate.Mobile/Android/MainActivity.Android.cs
@@ -17,11 +17,8 @@ public sealed class MainActivity : Microsoft.UI.Xaml.ApplicationActivity
 {
 	protected override void OnCreate(Bundle bundle)
 	{
-		if (Build.VERSION.SdkInt >= BuildVersionCodes.S)
-		{
-			// Support the ExtendedSplashScreen on Android 12+.
-			Nventive.ExtendedSplashScreen.ExtendedSplashScreen.AndroidSplashScreen = AndroidX.Core.SplashScreen.SplashScreen.InstallSplashScreen(this);
-		}
+		// Support the ExtendedSplashScreen on Android 12+.
+		Nventive.ExtendedSplashScreen.ExtendedSplashScreen.AndroidSplashScreen = AndroidX.Core.SplashScreen.SplashScreen.InstallSplashScreen(this);
 
 		base.OnCreate(bundle);
 	}

--- a/src/app/ApplicationTemplate.Mobile/Android/MainActivity.Android.cs
+++ b/src/app/ApplicationTemplate.Mobile/Android/MainActivity.Android.cs
@@ -17,8 +17,11 @@ public sealed class MainActivity : Microsoft.UI.Xaml.ApplicationActivity
 {
 	protected override void OnCreate(Bundle bundle)
 	{
-		// Support the ExtendedSplashScreen on Android 12+.
-		Nventive.ExtendedSplashScreen.ExtendedSplashScreen.AndroidSplashScreen = AndroidX.Core.SplashScreen.SplashScreen.InstallSplashScreen(this);
+		if (Build.VERSION.SdkInt >= BuildVersionCodes.S)
+		{
+			// Support the ExtendedSplashScreen on Android 12+.
+			Nventive.ExtendedSplashScreen.ExtendedSplashScreen.AndroidSplashScreen = AndroidX.Core.SplashScreen.SplashScreen.InstallSplashScreen(this);
+		}
 
 		base.OnCreate(bundle);
 	}

--- a/src/app/ApplicationTemplate.Mobile/Android/Resources/values/Styles.xml
+++ b/src/app/ApplicationTemplate.Mobile/Android/Resources/values/Styles.xml
@@ -4,6 +4,17 @@
 		<item name="android:windowIsTranslucent">true</item>
 		<item name="android:windowAnimationStyle">@android:style/Animation</item>
 	</style>
+
+	<!-- This defines the SplashScreen theme -->
+	<style name="AppTheme.Starting" parent="Theme.SplashScreen">
+		<!-- Set the splash screen background. -->
+		<item name="windowSplashScreenBackground">@color/primaryColor</item>
+		<!-- Use windowSplashScreenAnimatedIcon to add either a drawable or an animated drawable. -->
+		<item name="windowSplashScreenAnimatedIcon">@drawable/Logo</item>
+		<!-- Set the theme of the Activity that directly follows your splash screen. -->
+		<item name="postSplashScreenTheme">@style/AppTheme</item>
+	</style>
+	
 	<style name="AppTheme" parent="Theme.AppCompat.DayNight">
 		<!-- This removes the ActionBar -->
 		<item name="windowActionBar">false</item>


### PR DESCRIPTION
…roid 11 and lower

GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

## Description

The app was crashing for android 11 and lower when we called android 12 specific code for extended splashscreen.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [ ] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [x] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->