### PR TITLE
feat: Add tabs to the expanded DiagnosticsOverlay.

### DIFF
--- a/src/app/ApplicationTemplate.Presentation/Framework/ViewModels/IViewModel.Extensions.Deactivation.cs
+++ b/src/app/ApplicationTemplate.Presentation/Framework/ViewModels/IViewModel.Extensions.Deactivation.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Chinook.DynamicMvvm;
+using Chinook.DynamicMvvm.Deactivation;
+
+namespace Chinook.DynamicMvvm;
+
+/// <summary>
+/// This class exposes extensions methods on <see cref="IViewModel"/> related to the <see cref="IDeactivatable"/> pattern.
+/// </summary>
+public static class ChinookViewModelExtensionsForDeactivation
+{
+	/// <summary>
+	/// Adds a subcription that implements <see cref="IDeactivatable"/> to the <see cref="IViewModel"/> disposables.
+	/// </summary>
+	/// <param name="viewModel">The viewModel.</param>
+	/// <param name="subscribe">The subscribe function. It will be invoked every time the subscription reactivates.</param>
+	/// <param name="isDeactivated">Flag indicating whether the subscription should activate immediately. This is false by default meaning the subscription automatically activates.</param>
+	public static void AddDeactivatableSubscription(this IViewModel viewModel, Func<IDisposable> subscribe, bool isDeactivated = false)
+	{
+		var deactivatable = new DeactivableSubscription(subscribe);
+		viewModel.AddDisposable($"DeactivableSubscription_{Guid.NewGuid()}", deactivatable);
+	}
+
+	private sealed class DeactivableSubscription : IDeactivatable, IDisposable
+	{
+		private readonly Func<IDisposable> _subscribe;
+
+		private IDisposable _subscription;
+		private bool _isDisposed;
+
+		public DeactivableSubscription(Func<IDisposable> subscribe, bool isDeactivated = false)
+		{
+			_subscribe = subscribe;
+			IsDeactivated = isDeactivated;
+			if (!IsDeactivated)
+			{
+				_subscription = _subscribe();
+			}
+		}
+
+		public bool IsDeactivated { get; private set; }
+
+		public void Deactivate()
+		{
+			if (IsDeactivated || _isDisposed)
+			{
+				return;
+			}
+
+			_subscription?.Dispose();
+
+			IsDeactivated = true;
+		}
+
+		public void Reactivate()
+		{
+			if (!IsDeactivated || _isDisposed)
+			{
+				return;
+			}
+
+			_subscription = _subscribe();
+
+			IsDeactivated = false;
+		}
+
+		public void Dispose()
+		{
+			_isDisposed = true;
+			_subscription?.Dispose();
+		}
+	}
+}

--- a/src/app/ApplicationTemplate.Presentation/Framework/ViewModels/TabViewModel.cs
+++ b/src/app/ApplicationTemplate.Presentation/Framework/ViewModels/TabViewModel.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Chinook.DynamicMvvm;
+using Chinook.DynamicMvvm.Deactivation;
+using Uno;
+
+namespace ApplicationTemplate.Presentation;
+
+/// <summary>
+/// Represents a ViewModel of a Tab.
+/// A tab can be active or not.
+/// </summary>
+public abstract class TabViewModel : DeactivatableViewModelBase
+{
+	protected TabViewModel()
+	{
+		(this as IInjectable)?.Inject((t, n) => this.GetService(t));
+	}
+
+	/// <summary>
+	/// Gets the title of this Tab.
+	/// This is to be displayed in a TabBar.
+	/// </summary>
+	public string Title { get; init; }
+
+	/// <summary>
+	/// Gets or sets a value indicating whether this tab is the active one.
+	/// </summary>
+	public bool IsActiveTab { get; set; }
+
+	/// <inheritdoc/>
+	/// <remarks>
+	/// In the specific case of <see cref="TabViewModel"/>, reactivation will not happen unless <see cref="IsActiveTab"/> is true.
+	/// </remarks>
+	public override void Reactivate()
+	{
+		if (IsActiveTab)
+		{
+			base.Reactivate();
+		}
+	}
+}
+
+public static class TabViewModelExtensions
+{
+	/// <summary>
+	/// Deactivates inactive tabs and reactivates the active tab.
+	/// This ensures only 1 item from <paramref name="tabs"/> has <see cref="IDeactivatable.IsDeactivated"/> set to false.
+	/// </summary>
+	/// <param name="tabs">The items to deactivate and reactivate.</param>
+	/// <param name="activeTabIndex">The active tab index indicating which tab should be reactivated.</param>
+	public static void SetActiveTabIndex(this TabViewModel[] tabs, int activeTabIndex)
+	{
+		for (int i = 0; i < tabs.Length; i++)
+		{
+			var tab = tabs[i];
+			if (i == activeTabIndex)
+			{
+				tab.IsActiveTab = true;
+				tab.Reactivate();
+			}
+			else
+			{
+				tab.IsActiveTab = false;
+				tab.Deactivate();
+			}
+		}
+	}
+}

--- a/src/app/ApplicationTemplate.Presentation/ViewModels/Diagnostics/HttpDebugger/HttpTraceItemViewModel.cs
+++ b/src/app/ApplicationTemplate.Presentation/ViewModels/Diagnostics/HttpDebugger/HttpTraceItemViewModel.cs
@@ -6,7 +6,7 @@ using Chinook.DynamicMvvm;
 
 namespace ApplicationTemplate.Presentation;
 
-public class HttpTraceItemViewModel : ViewModel
+public sealed class HttpTraceItemViewModel : ViewModel
 {
 	private readonly HttpTrace _trace;
 

--- a/src/app/ApplicationTemplate.Presentation/ViewModels/Diagnostics/Navigation/NavigationDebuggerViewModel.cs
+++ b/src/app/ApplicationTemplate.Presentation/ViewModels/Diagnostics/Navigation/NavigationDebuggerViewModel.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ApplicationTemplate.Presentation;
+
+public sealed class NavigationDebuggerViewModel : TabViewModel
+{
+	public NavigationDebuggerViewModel()
+	{
+		Title = "Navigation";
+	}
+}

--- a/src/app/ApplicationTemplate.Shared.Views/ApplicationTemplate.Shared.Views.projitems
+++ b/src/app/ApplicationTemplate.Shared.Views/ApplicationTemplate.Shared.Views.projitems
@@ -48,6 +48,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Content\Diagnostics\DiagnosticsPage.xaml.cs">
       <DependentUpon>DiagnosticsPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Content\Diagnostics\DiagnosticsTabPresenter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Content\Diagnostics\EnvironmentPickerPage.xaml.cs">
       <DependentUpon>EnvironmentPickerPage.xaml</DependentUpon>
     </Compile>

--- a/src/app/ApplicationTemplate.Shared.Views/Content/Diagnostics/DiagnosticsOverlay.xaml
+++ b/src/app/ApplicationTemplate.Shared.Views/Content/Diagnostics/DiagnosticsOverlay.xaml
@@ -24,7 +24,7 @@
 			<uc:FromNullableBoolToCustomValueConverter x:Key="IsExpandedToCornerRadius"
 													   TrueValue="0"
 													   NullOrFalseValue="8,0,0,8" />
-			
+
 			<!-- Diagnostics Counter TextBlockStyle -->
 			<Style x:Key="DiagnosticsCounterTextBlockStyle"
 				   TargetType="TextBlock">
@@ -50,7 +50,7 @@
 			<!-- Diagnostics Overlay ButtonStyle -->
 			<Style x:Key="DiagnosticsOverlayButtonStyle"
 				   TargetType="Button">
-				
+
 				<Setter Property="FontSize"
 						Value="11" />
 				<Setter Property="HorizontalAlignment"
@@ -71,11 +71,11 @@
 						Value="0" />
 				<Setter Property="MinHeight"
 						Value="0" />
-				
+
 				<Setter Property="Template">
 					<Setter.Value>
 						<ControlTemplate TargetType="Button">
-							
+
 							<Grid VerticalAlignment="{TemplateBinding VerticalAlignment}"
 								  HorizontalAlignment="{TemplateBinding HorizontalAlignment}">
 
@@ -114,18 +114,153 @@
 					</Setter.Value>
 				</Setter>
 			</Style>
+
+			<Style x:Key="DiagnosticsTabListViewItemStyle"
+				   TargetType="ListViewItem">
+
+				<Setter Property="Background"
+						Value="#BB000000" />
+				<Setter Property="HorizontalContentAlignment"
+						Value="Stretch" />
+				<Setter Property="VerticalAlignment"
+						Value="Top" />
+				<Setter Property="VerticalContentAlignment"
+						Value="Stretch" />
+				<Setter Property="MinHeight"
+						Value="0" />
+				<Setter Property="MinWidth"
+						Value="0" />
+				<Setter Property="Padding"
+						Value="4" />
+
+				<Setter Property="Template">
+					<Setter.Value>
+						<ControlTemplate TargetType="ListViewItem">
+
+							<Grid x:Name="ContentBorder"
+								  Background="{TemplateBinding Background}"
+								  BorderBrush="{TemplateBinding BorderBrush}"
+								  BorderThickness="{TemplateBinding BorderThickness}">
+
+								<VisualStateManager.VisualStateGroups>
+									<VisualStateGroup x:Name="CommonStates">
+										<VisualState x:Name="Normal" />
+										<VisualState x:Name="PointerOver" />
+										<VisualState x:Name="Pressed" />
+										<VisualState x:Name="Selected">
+											<VisualState.Setters>
+												<Setter Target="SelectionIndicator.Opacity"
+														Value="1" />
+											</VisualState.Setters>
+										</VisualState>
+										<VisualState x:Name="PointerOverSelected">
+											<VisualState.Setters>
+												<Setter Target="SelectionIndicator.Opacity"
+														Value="1" />
+											</VisualState.Setters>
+										</VisualState>
+										<VisualState x:Name="PressedSelected">
+											<VisualState.Setters>
+												<Setter Target="SelectionIndicator.Opacity"
+														Value="1" />
+											</VisualState.Setters>
+										</VisualState>
+									</VisualStateGroup>
+
+									<VisualStateGroup x:Name="DisabledStates">
+										<VisualState x:Name="Enabled" />
+										<VisualState x:Name="Disabled" />
+									</VisualStateGroup>
+
+									<!-- For MultiSelectStates states, use the complete style in Uno.UI. See links on top of this file. -->
+									<VisualStateGroup x:Name="MultiSelectStates" />
+
+									<!-- For reordering states, use the complete style in Uno.UI. See links on top of this file.-->
+									<VisualStateGroup x:Name="ReorderHintStates" />
+
+									<!-- For drag states, use the complete style in Uno.UI. See links on top of this file. -->
+									<VisualStateGroup x:Name="DragStates" />
+								</VisualStateManager.VisualStateGroups>
+
+								<Rectangle x:Name="SelectionIndicator"
+										   IsHitTestVisible="False"
+										   HorizontalAlignment="Stretch"
+										   VerticalAlignment="Bottom"
+										   Height="1"
+										   Fill="White"
+										   Opacity="0" />
+
+								<!-- ContentPresenter -->
+								<ContentPresenter x:Name="ContentPresenter"
+												  Margin="{TemplateBinding Padding}"
+												  Content="{TemplateBinding Content}"
+												  ContentTransitions="{TemplateBinding ContentTransitions}"
+												  ContentTemplate="{TemplateBinding ContentTemplate}"
+												  xamarin:ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+												  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+												  VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+							</Grid>
+						</ControlTemplate>
+					</Setter.Value>
+				</Setter>
+			</Style>
+
+			<Style x:Key="DiagnosticsHorizontalListViewStyle"
+				   TargetType="ListView"
+				   BasedOn="{StaticResource DefaultListViewStyle}">
+
+				<Setter Property="ItemsPanel">
+					<Setter.Value>
+						<ItemsPanelTemplate>
+							<StackPanel Orientation="Horizontal" />
+						</ItemsPanelTemplate>
+					</Setter.Value>
+				</Setter>
+
+				<Setter Property="Template">
+					<Setter.Value>
+						<ControlTemplate TargetType="ListView">
+							<ScrollViewer x:Name="ScrollViewer"
+										  xamarin:Style="{StaticResource ListViewBaseScrollViewerStyle}"
+										  TabNavigation="{TemplateBinding TabNavigation}"
+										  HorizontalScrollMode="Enabled"
+										  HorizontalScrollBarVisibility="Hidden"
+										  IsHorizontalScrollChainingEnabled="True"
+										  IsHorizontalRailEnabled="True"
+										  VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
+										  VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+										  IsVerticalScrollChainingEnabled="{TemplateBinding ScrollViewer.IsVerticalScrollChainingEnabled}"
+										  IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
+										  ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
+										  IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+										  BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
+										  AutomationProperties.AccessibilityView="Raw">
+
+								<ItemsPresenter Header="{TemplateBinding Header}"
+												HeaderTemplate="{TemplateBinding HeaderTemplate}"
+												HeaderTransitions="{TemplateBinding HeaderTransitions}"
+												Footer="{TemplateBinding Footer}"
+												FooterTemplate="{TemplateBinding FooterTemplate}"
+												FooterTransitions="{TemplateBinding FooterTransitions}"
+												Padding="{TemplateBinding Padding}" />
+							</ScrollViewer>
+						</ControlTemplate>
+					</Setter.Value>
+				</Setter>
+			</Style>
+
 		</ResourceDictionary>
 	</UserControl.Resources>
 
 	<Grid>
-		
+
 		<Grid Background="#AA000000"
 			  BorderThickness="1"
 			  BorderBrush="#000000"
 			  CornerRadius="{Binding IsDiagnosticsExpanded, Converter={StaticResource IsExpandedToCornerRadius}}"
 			  HorizontalAlignment="{Binding IsDiagnosticsExpanded, Converter={StaticResource TrueToHorizontalStretch}, FallbackValue=Right}"
 			  VerticalAlignment="{Binding IsDiagnosticsExpanded, Converter={StaticResource TrueToVerticalStretch}, FallbackValue=Top}"
-			  Padding="2,2,0,2"
+			  Padding="0"
 			  Margin="0,100,0,0">
 
 			<Grid.RowDefinitions>
@@ -232,14 +367,35 @@
 
 			<!-- Diagnostics expanded content -->
 			<Grid Visibility="{Binding IsDiagnosticsExpanded, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
-						Grid.Row="0"
-						Grid.RowSpan="3"
-						Padding="0,0,50,0">
+				  Grid.Row="0"
+				  Grid.RowSpan="3"
+				  Padding="0,0,50,0">
+				<Grid.RowDefinitions>
+					<RowDefinition Height="Auto" />
+					<RowDefinition Height="*" />
+				</Grid.RowDefinitions>
 
-				<!-- Custom Diagnostics content; currently the HttpDebuggerView. -->
-				<diag:HttpDebuggerView DataContext="{Binding HttpDebugger}"
-									   VerticalAlignment="Stretch"/>
+				<!-- Tab bar -->
+				<ListView Style="{StaticResource DiagnosticsHorizontalListViewStyle}"
+						  ItemsSource="{Binding Tabs}"
+						  ItemContainerStyle="{StaticResource DiagnosticsTabListViewItemStyle}"
+						  SelectionMode="Single"
+						  SelectedIndex="{Binding ActiveTabIndex, Mode=TwoWay}">
+					<ListView.ItemTemplate>
+						<DataTemplate>
+							<StackPanel>
+								<TextBlock Text="{Binding Title}"
+										   Foreground="White"
+										   FontSize="12"/>
+							</StackPanel>
+						</DataTemplate>
+					</ListView.ItemTemplate>
+				</ListView>
 
+				<!-- Active diagnostics tab. (This includes things like the HttpDebuggerView.) -->
+				<diag:DiagnosticsTabPresenter ViewModel="{Binding ActiveTabViewModel}"
+											  Grid.Row="1"
+											  Margin="2,2,2,0" />
 			</Grid>
 
 			<StackPanel HorizontalAlignment="Right"
@@ -258,7 +414,7 @@
 				<!-- Toggle Alignment Grid Button -->
 				<Button Content="Grid"
 						Command="{Binding ToggleAlignmentGrid}"
-						Style="{StaticResource DiagnosticsOverlayButtonStyle}" />				
+						Style="{StaticResource DiagnosticsOverlayButtonStyle}" />
 
 				<!-- Theme Button -->
 				<Button Content="Theme"

--- a/src/app/ApplicationTemplate.Shared.Views/Content/Diagnostics/DiagnosticsTabPresenter.cs
+++ b/src/app/ApplicationTemplate.Shared.Views/Content/Diagnostics/DiagnosticsTabPresenter.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using ApplicationTemplate.Presentation;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace ApplicationTemplate.Views.Content.Diagnostics;
+
+/// <summary>
+/// This view shows the current Diagnostics tab.
+/// It maps ViewModels to the corresponding view.
+/// </summary>
+public sealed partial class DiagnosticsTabPresenter : ContentControl
+{
+	public TabViewModel ViewModel
+	{
+		get { return (TabViewModel)GetValue(ViewModelProperty); }
+		set { SetValue(ViewModelProperty, value); }
+	}
+
+	public static readonly DependencyProperty ViewModelProperty =
+		DependencyProperty.Register("ViewModel", typeof(TabViewModel), typeof(DiagnosticsTabPresenter), new PropertyMetadata(null, OnViewModelChanged));
+
+	private static void OnViewModelChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+	{
+		var that = (DiagnosticsTabPresenter)d;
+		that.Content = e.NewValue switch
+		{
+			HttpDebuggerViewModel => new HttpDebuggerView() { DataContext = e.NewValue },
+			_ => new Border(),
+		};
+	}
+}

--- a/src/app/ApplicationTemplate.Shared.Views/Content/Diagnostics/HttpDebuggerView.xaml.cs
+++ b/src/app/ApplicationTemplate.Shared.Views/Content/Diagnostics/HttpDebuggerView.xaml.cs
@@ -38,8 +38,15 @@ public sealed partial class HttpDebuggerView : UserControl
 
 	private void OnUnloaded(object sender, RoutedEventArgs e)
 	{
+//-:cnd:noEmit
+#if __WINDOWS__
+		var currentWindow = App.Instance.CurrentWindow;
+		currentWindow.SizeChanged -= OnSizeChanged;
+#else
 		var applicationView = ApplicationView.GetForCurrentView();
 		applicationView.VisibleBoundsChanged -= OnVisibleBoundsChanged;
+#endif
+//+:cnd:noEmit
 	}
 
 	private void OnSizeChanged(object sender, WindowSizeChangedEventArgs args)


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Feature

## Description

<!-- (Please describe the changes that this PR introduces.) -->
- Add tabs to the expanded DiagnosticsOverlay.
  There's currently 2 tabs: HTTP (`HttpDebuggerView`) and Navigation (empty for now).

![diag-tabs](https://user-images.githubusercontent.com/39710855/223741936-46f9fc58-2e13-476d-8d67-707f05453c67.gif)

## PR Checklist 
Please check if your PR fulfills the following requirements:

- [x] Interface members are XML documented
- [x] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [x] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->