### PR TITLE
fix: Connectivity provider

### DIFF
--- a/src/app/ApplicationTemplate.Shared.Views/Framework/Connectivity/ConnectivityProvider.cs
+++ b/src/app/ApplicationTemplate.Shared.Views/Framework/Connectivity/ConnectivityProvider.cs
@@ -19,14 +19,15 @@ public sealed class ConnectivityProvider : IConnectivityProvider, IDisposable
 			{
 				_subscribed = true;
 				NetworkInformation.NetworkStatusChanged += OnNetworkStatusChanged;
+				this.Log().Debug("Subscribed to NetworkInformation.NetworkStatusChanged.");
 			}
 			InnerConnectivityChanged += value;
 		}
 
 		remove
 		{
-			UnsubscribeLocalEvent();
 			InnerConnectivityChanged -= value;
+			UnsubscribeLocalEvent();
 		}
 	}
 
@@ -64,17 +65,18 @@ public sealed class ConnectivityProvider : IConnectivityProvider, IDisposable
 
 	public void Dispose()
 	{
-		UnsubscribeLocalEvent();
 		InnerConnectivityChanged = null;
+		UnsubscribeLocalEvent();
 		GC.SuppressFinalize(this);
 	}
 
 	private void UnsubscribeLocalEvent()
 	{
-		if (_subscribed)
+		if (_subscribed && InnerConnectivityChanged is null)
 		{
 			_subscribed = false;
 			NetworkInformation.NetworkStatusChanged -= OnNetworkStatusChanged;
+			this.Log().Debug("Unsubscribed to NetworkInformation.NetworkStatusChanged because no subscriptions were left on the ConnectivityProvider.ConnectivityChanged event.");
 		}
 	}
 


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

## Description

<!-- (Please describe the changes that this PR introduces.) -->

Made it so that if you unsuscribe to the connectivity event, the service will not unsuscribe from the NetworkStatusChanged Event unless there are no other subscription to the connectivity event.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [ ] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [x] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->