### PR TITLE
feat: add a close button on diagnostic overlay

### DIFF
--- a/src/app/ApplicationTemplate.Presentation/ViewModels/Diagnostics/DiagnosticsOverlayViewModel.cs
+++ b/src/app/ApplicationTemplate.Presentation/ViewModels/Diagnostics/DiagnosticsOverlayViewModel.cs
@@ -46,18 +46,38 @@ public sealed partial class DiagnosticsOverlayViewModel : ViewModel
 		await this.GetService<ISectionsNavigator>().OpenModal(ct, () => new DiagnosticsPageViewModel());
 	});
 
+	/// <summary>
+	/// Gets a value indicating whether the diagnostic overlay has been enabled by the user.
+	/// </summary>
 	public bool IsDiagnosticsOverlayEnabled => this.GetFromOptionsMonitor<DiagnosticsOptions, bool>(o => o.IsDiagnosticsOverlayEnabled);
 
-	public bool IsAlignmentGridEnabled
+	/// <summary>
+	/// Gets a value indicating whether gets whether the user has closed manually the diagnostic overlay.
+	/// </summary>
+	public bool IsClosed
 	{
 		get => this.Get<bool>();
-		set => this.Set(value);
+		private set => this.Set(value);
 	}
 
-	public IDynamicCommand ToggleAlignmentGrid => this.GetCommand(() =>
+	public IDynamicCommand CloseDiagnostic => this.GetCommand(() =>
 	{
-		IsAlignmentGridEnabled = !IsAlignmentGridEnabled;
+		IsClosed = true;
 	});
+
+	/// <summary>
+	/// Gets a value indicating whether the diagnostic overlay should be displayed.
+	/// </summary>
+	public bool ShouldDisplayOverlay => this.GetFromObservable(ObserveShouldDisplayOverlay(), initialValue: IsDiagnosticsOverlayEnabled);
+
+	private IObservable<bool> ObserveShouldDisplayOverlay()
+	{
+		return Observable.CombineLatest(
+			this.GetProperty(x => x.IsDiagnosticsOverlayEnabled).GetAndObserve(),
+			this.GetProperty(x => x.IsClosed).GetAndObserve(),
+			(isEnabled, isClosed) => isEnabled && !isClosed
+		);
+	}
 
 	public IDynamicCommand ToggleHttpDebugger => this.GetCommand(() =>
 	{

--- a/src/app/ApplicationTemplate.Shared.Views/Content/Diagnostics/DiagnosticsOverlay.xaml
+++ b/src/app/ApplicationTemplate.Shared.Views/Content/Diagnostics/DiagnosticsOverlay.xaml
@@ -386,7 +386,7 @@
 							<StackPanel>
 								<TextBlock Text="{Binding Title}"
 										   Foreground="White"
-										   FontSize="12"/>
+										   FontSize="12" />
 							</StackPanel>
 						</DataTemplate>
 					</ListView.ItemTemplate>
@@ -411,11 +411,6 @@
 						Command="{Binding ToggleHttpDebugger}"
 						Style="{StaticResource DiagnosticsOverlayButtonStyle}" />
 
-				<!-- Toggle Alignment Grid Button -->
-				<Button Content="Grid"
-						Command="{Binding ToggleAlignmentGrid}"
-						Style="{StaticResource DiagnosticsOverlayButtonStyle}" />
-
 				<!-- Theme Button -->
 				<Button Content="Theme"
 						Click="OnThemeButtonClicked"
@@ -435,6 +430,11 @@
 								   Visibility="{Binding IsDiagnosticsExpanded, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}" />
 					</Grid>
 				</Button>
+
+				<!-- Close Button -->
+				<Button Content="X"
+						Command="{Binding CloseDiagnostic}"
+						Style="{StaticResource DiagnosticsOverlayButtonStyle}" />
 			</StackPanel>
 		</Grid>
 	</Grid>

--- a/src/app/ApplicationTemplate.Shared.Views/Shell.xaml
+++ b/src/app/ApplicationTemplate.Shared.Views/Shell.xaml
@@ -25,7 +25,7 @@
 					Grid.Row="1" />
 
 		<local:DiagnosticsOverlay DataContext="{Binding DiagnosticsOverlay}"
-								  Visibility="{Binding IsDiagnosticsOverlayEnabled, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
+								  Visibility="{Binding ShouldDisplayOverlay, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
 								  Grid.RowSpan="2" />
 
 		<splash:ExtendedSplashScreen x:Name="AppExtendedSplashScreen"


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Feature

## Description

I've added a button to temporarily close the diagnostic overlay so it be hidden especially when developing especially on stuff that can be hidden by the overlay.

![close](https://user-images.githubusercontent.com/17461593/232798438-4bfbf0a2-4428-445d-a21d-8d8cd7252b86.gif)

## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] ~~Interface members are XML documented~~
- [ ] ~~Documentation (XML or comments) has been added and/or existing documentation has been updated~~
- [ ] ~~[Architecture documents](./doc/Architecture.md) have been updated~~
- [x] Tested on all relevant platforms (Only WinUI)

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->