### PR TITLE
fix(283022): fix app crash when focus or type in some fields

### DIFF
--- a/src/app/ApplicationTemplate.Shared.Views/Behaviors/FormattingTextBoxBehavior.cs
+++ b/src/app/ApplicationTemplate.Shared.Views/Behaviors/FormattingTextBoxBehavior.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Text;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Uno.Extensions;
@@ -195,7 +196,7 @@ public sealed partial class FormattingTextBoxBehavior
 			return;
 		}
 
-		_ = textbox.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+		_ = textbox.DispatcherQueue.RunAsync(DispatcherQueuePriority.Normal, () =>
 		{
 			textbox.Text = formattedText;
 			textbox.SelectionStart = selectionStart;

--- a/src/app/ApplicationTemplate.Shared.Views/Behaviors/FormattingTextBoxBehavior.iOS.cs
+++ b/src/app/ApplicationTemplate.Shared.Views/Behaviors/FormattingTextBoxBehavior.iOS.cs
@@ -134,11 +134,7 @@ public sealed partial class FormattingTextBoxBehavior
 		}
 
 #region restore uno implementations
-		//public override bool ShouldChangeCharacters(UITextField textField, NSRange range, string replacementString) => _delegate.ShouldChangeCharacters(textField, range, replacementString);
-
 		public override bool ShouldReturn(UITextField textField) => _delegate.ShouldReturn(textField);
-
-		public override bool ShouldBeginEditing(UITextField textField) => _delegate.ShouldBeginEditing(textField);
 
 		public override void EditingStarted(UITextField textField) => _delegate.EditingStarted(textField);
 

--- a/src/app/ApplicationTemplate.Shared.Views/Content/Settings/SettingsPage.xaml
+++ b/src/app/ApplicationTemplate.Shared.Views/Content/Settings/SettingsPage.xaml
@@ -108,7 +108,7 @@
 					<Button Content="REPLAY TUTORIAL"
 							x:Uid="Settings_ReplayTutorial"
 							Command="{Binding NavigateToOnboardingPage}"
-							Style="{StaticResource ContainedSecondaryButtonStyle}"
+							Style="{StaticResource FilledButtonStyle}"
 							HorizontalAlignment="Left"
 							Margin="0,16,0,0" />
 				</StackPanel>


### PR DESCRIPTION

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

## Description

<!-- (Please describe the changes that this PR introduces.) -->
fix app crash when focus (iOS) or type (on Windows) in Postal Code and Phone Number fields

## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [ ] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [x] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

[Bug 283022](https://dev.azure.com/nventive/Practice%20committees/_workitems/edit/283022): App crash on Create Account page when some fields get focused