### PR TITLE
fix: add provisioning profile to project for iOS deployment

### DIFF
--- a/src/app/ApplicationTemplate.Mobile/ApplicationTemplate.Mobile.csproj
+++ b/src/app/ApplicationTemplate.Mobile/ApplicationTemplate.Mobile.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
@@ -159,6 +159,8 @@
 				<!-- See https://github.com/xamarin/xamarin-macios/issues/14812 for more details. -->
 				<MtouchExtraArgs>$(MtouchExtraArgs) --marshal-objectivec-exceptions:disable</MtouchExtraArgs>
 				<CodesignEntitlements>iOS\Entitlements.plist</CodesignEntitlements>
+				<ProvisioningType>manual</ProvisioningType>
+				<CodesignProvision>ApplicationTemplate - Development</CodesignProvision>
 			</PropertyGroup>
 			<Choose>
 				<When Condition="'$(Configuration)'=='Debug'">

--- a/src/app/ApplicationTemplate.Mobile/iOS/Info.plist
+++ b/src/app/ApplicationTemplate.Mobile/iOS/Info.plist
@@ -5,7 +5,7 @@
 		<key>CFBundleDisplayName</key>
 		<string>ApplicationTemplate</string>
 		<key>CFBundleIdentifier</key>
-		<string>com.nventive.internal.applicationtemplate</string>
+		<string>com.nventive.applicationtemplate</string>
 		<key>CFBundleShortVersionString</key>
 		<string>1.0.0</string>
 		<key>CFBundleVersion</key>


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

## Description
<!-- (Please describe the changes that this PR introduces.) -->
This PR fixes the iOS deployment on physical devices as no provisioning profile was included in the project. The `CFBundleIdentifier` was changed to the name of the profile that has been created.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [ ] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [ ] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->