### PR TITLE
feat: decode OS version for diagnostic

### DIFF
--- a/src/app/ApplicationTemplate.Presentation/ViewModels/Diagnostics/SummaryDiagnosticsViewModel.cs
+++ b/src/app/ApplicationTemplate.Presentation/ViewModels/Diagnostics/SummaryDiagnosticsViewModel.cs
@@ -58,7 +58,7 @@ public partial class SummaryDiagnosticsViewModel : ViewModel
 		stringBuilder.AppendLine($"Build: {versionProvider.BuildString}");
 
 		stringBuilder.AppendLine($"OS: {deviceInformationProvider.OperatingSystem}");
-		stringBuilder.AppendLine($"OS version: {deviceInformationProvider.OperatingSystemVersion}");
+		stringBuilder.AppendLine($"OS version: {DecodeSytemVersion(deviceInformationProvider.OperatingSystemVersion)}");
 		stringBuilder.AppendLine($"Device type: {deviceInformationProvider.DeviceType}");
 
 		// UserAgent Not available in X.E but we could do it in app, here's the implementation.
@@ -138,5 +138,16 @@ public partial class SummaryDiagnosticsViewModel : ViewModel
 		}
 
 		return stringBuilder.ToString();
+	}
+
+	private Version DecodeSytemVersion(string operatingSystemVersion)
+	{
+		// The OS Version provided from DeviceFamilyVersion needs to be decoded to show the OS Version that we commonly use.
+		var v = ulong.Parse(operatingSystemVersion);
+		var major = (v & 0xFFFF000000000000L) >> 48;
+		var minor = (v & 0x0000FFFF00000000L) >> 32;
+		var build = (v & 0x00000000FFFF0000L) >> 16;
+		var revision = v & 0x000000000000FFFFL;
+		return new Version((int)major, (int)minor, (int)build, (int)revision);
 	}
 }


### PR DESCRIPTION
GitHub Issue: #
related to https://github.com/unoplatform/uno/discussions/10985
## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Feature


## Description

<!-- (Please describe the changes that this PR introduces.) -->
Decode OS version for diagnostic.
When using DeviceFamilyVersion, we receive 4503616807370751 for iOS version, the decoding gives 16.4.1

## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [ ] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [x] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->