### PR TITLE
feat: Add button to delete configuration override file

### DIFF
--- a/src/app/ApplicationTemplate.Presentation/Configuration/ReadOnlyConfigurationOptions.cs
+++ b/src/app/ApplicationTemplate.Presentation/Configuration/ReadOnlyConfigurationOptions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ApplicationTemplate;
+
+/// <summary>
+/// Represents the configuration options that can't be overriden.
+/// All its values can only be set in code (and cannot be read from an appsettings.json file).
+/// </summary>
+public class ReadOnlyConfigurationOptions
+{
+	/// <summary>
+	/// Gets or sets the folder path containing the override files (such as appsettings.override.json).
+	/// </summary>
+	public string ConfigurationOverrideFolderPath { get; set; }
+
+	/// <summary>
+	/// Gets or sets the default environment for which the app was built for.
+	/// </summary>
+	public string DefaultEnvironment { get; set; }
+}

--- a/src/app/ApplicationTemplate.Presentation/Framework/Diagnostics/IDiagnosticsService.cs
+++ b/src/app/ApplicationTemplate.Presentation/Framework/Diagnostics/IDiagnosticsService.cs
@@ -8,6 +8,8 @@ namespace ApplicationTemplate;
 
 public interface IDiagnosticsService
 {
+	void DeleteConfigurationOverrideFile();
+
 	Task TestExceptionFromMainThread(CancellationToken ct);
 
 	void OpenSettingsFolder();

--- a/src/app/ApplicationTemplate.Shared.Views/Content/Diagnostics/ConfigurationDebuggerView.xaml
+++ b/src/app/ApplicationTemplate.Shared.Views/Content/Diagnostics/ConfigurationDebuggerView.xaml
@@ -89,13 +89,80 @@
 			</Setter>
 		</Style>
 
+		<Style x:Key="ConfigurationDebuggerButtonStyle"
+			   TargetType="Button">
+
+			<Setter Property="FontSize"
+					Value="12" />
+			<Setter Property="HorizontalAlignment"
+					Value="Left" />
+			<Setter Property="Foreground"
+					Value="White" />
+			<Setter Property="Background"
+					Value="#AA000000" />
+			<Setter Property="Padding"
+					Value="4,4" />
+			<Setter Property="MinWidth"
+					Value="0" />
+			<Setter Property="Margin"
+					Value="0,1" />
+			<Setter Property="BorderThickness"
+					Value="0" />
+			<Setter Property="MinHeight"
+					Value="0" />
+
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="Button">
+
+						<Grid VerticalAlignment="{TemplateBinding VerticalAlignment}"
+							  HorizontalAlignment="{TemplateBinding HorizontalAlignment}">
+
+							<VisualStateManager.VisualStateGroups>
+								<VisualStateGroup x:Name="CommonStates">
+									<VisualState x:Name="Normal" />
+									<VisualState x:Name="PointerOver" />
+									<VisualState x:Name="Pressed">
+										<VisualState.Setters>
+											<Setter Target="BackgroundBorder.Opacity"
+													Value="0.8" />
+										</VisualState.Setters>
+									</VisualState>
+									<VisualState x:Name="Disabled" />
+								</VisualStateGroup>
+							</VisualStateManager.VisualStateGroups>
+
+							<!-- Background Border -->
+							<Border x:Name="BackgroundBorder"
+									Background="{TemplateBinding Background}"
+									BorderThickness="{TemplateBinding BorderThickness}"
+									BorderBrush="{TemplateBinding BorderBrush}" />
+
+							<!-- ContentPresenter -->
+							<ContentPresenter x:Name="ContentPresenter"
+											  Margin="{TemplateBinding Padding}"
+											  Content="{TemplateBinding Content}"
+											  ContentTemplate="{TemplateBinding ContentTemplate}"
+											  AutomationProperties.AccessibilityView="Raw"
+											  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+						</Grid>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+
 	</UserControl.Resources>
 
 	<Grid>
 		<ScrollViewer>
-			<StackPanel>
+			<StackPanel Margin="0,0,0,200">
 				<TextBox Text="{Binding ConfigurationAsJson}"
 						 Style="{StaticResource ConfigurationDebuggerTextBoxStyle}" />
+
+				<Button Content="Delete configuration override file"
+						Command="{Binding DeleteConfigurationOverride}"
+						Style="{StaticResource ConfigurationDebuggerButtonStyle}"/>
 			</StackPanel>
 		</ScrollViewer>
 

--- a/src/app/ApplicationTemplate.Shared.Views/Framework/DiagnosticsService.cs
+++ b/src/app/ApplicationTemplate.Shared.Views/Framework/DiagnosticsService.cs
@@ -1,8 +1,12 @@
 ﻿using System;
+using System.IO;
 using System.Reactive.Concurrency;
 using System.Threading;
 using System.Threading.Tasks;
 using MessageDialogService;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Windows.Storage;
 
 namespace ApplicationTemplate.Views;
@@ -11,11 +15,25 @@ public class DiagnosticsService : IDiagnosticsService
 {
 	private readonly IMessageDialogService _messageDialogService;
 	private readonly IDispatcherScheduler _dispatcherScheduler;
+	private readonly IOptions<ReadOnlyConfigurationOptions> _configurationOptions;
+	private readonly ILogger _logger;
 
-	public DiagnosticsService(IMessageDialogService messageDialogService, IDispatcherScheduler dispatcherScheduler)
+	public DiagnosticsService(IMessageDialogService messageDialogService, IDispatcherScheduler dispatcherScheduler, IOptions<ReadOnlyConfigurationOptions> configurationOptions, ILogger<DiagnosticsService> logger)
 	{
 		_messageDialogService = messageDialogService;
 		_dispatcherScheduler = dispatcherScheduler;
+		_configurationOptions = configurationOptions;
+		_logger = logger;
+	}
+
+	public void DeleteConfigurationOverrideFile()
+	{
+		_logger.LogDebug("Deleting configuration override file.");
+
+		var filePath = Path.Combine(_configurationOptions.Value.ConfigurationOverrideFolderPath, ConfigurationConfiguration.AppSettingsOverrideFileNameWithExtension);
+		File.Delete(filePath);
+
+		_logger.LogInformation("Deleted configuration override file.");
 	}
 
 	public bool CanOpenSettingsFolder { get; } =


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Feature

## Description

<!-- (Please describe the changes that this PR introduces.) -->

- Add button to delete the configuration override file (appsettings.override.json) from the Configuration tab of the expanded diagnostics overlay.

https://github.com/nventive/UnoApplicationTemplate/assets/39710855/50256ee0-03c0-45c9-8027-646bf4a1c75c

## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [x] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [x] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->