### PR TITLE
feat: Add environment switcher in the configuration diagnostics. Add …

### DIFF
--- a/doc/Environments.md
+++ b/doc/Environments.md
@@ -1,4 +1,4 @@
-# Environments
+﻿# Environments
 
 We use [Microsoft.Extensions.Hosting](https://www.nuget.org/packages/Microsoft.Extensions.Hosting) for any environment related work.
 
@@ -17,13 +17,10 @@ You can add / remove runtime environments by simply adding or removing appsettin
 This is governed by `IEnvironmentManager` and configured inside the [ConfigurationConfiguration.cs](../src/app/ApplicationTemplate.Presentation/Configuration/ConfigurationConfiguration.cs) file.
 
 - The default runtime environment is set based on a compile-time directive (e.g. production).
-
 - You can get the current environment using `IEnvironmentManager.Current`.
-
 - You can get all the possible environments using `IEnvironmentManager.AvailableEnvironments`.
-
-- You can set the current environment using `IEnvironmentManager.Override`. If the environment doesn't exist, you will get an exception.
-
+- You can set the environment using `IEnvironmentManager.Override`. If the environment doesn't exist, you will get an exception.
+  - You can see what will be the next environment using `IEnvironmentManager.Next` (because `Current` might not change instantly).
 - When using `EnvironmentManager` (the default implementation of `IEnvironmentManager`), the current environment is persisted into a file that is processed at startup; this allows the environment to affect your IoC and be faster than accessing any settings service (e.g. no IoC, no deserialization, etc.).
 
 - The current environment is also used when configuring the `IHostBuilder`. For example, you can do the following:
@@ -65,14 +62,16 @@ var myResult = MyApi.GetAll("myapi-dev/results");
 #endif
 
 // Do this
-if (GetRuntimeEnvironment() == "production") { ... }
+if (_environmentManager.Current == "PRODUCTION") { ... }
 ```
 
 ## Diagnostics
 
-Multiple environment features can be tested from the diagnostics screen. This is configured in [SummaryDiagnosticsViewModel](../src/app/ApplicationTemplate.Shared/Presentation/Diagnostics/SummaryDiagnosticsViewModel.cs).
+Multiple environment features can be tested from the diagnostics overlay. This is configured in [ConfigurationDebuggerViewModel](../src/app/ApplicationTemplate.Presentation/ViewModels/Diagnostics/Configuration/ConfigurationDebuggerViewModel.cs).
 
-- You can see the current runtime environment. 
+- You can see the current runtime environment.
+- You can see what the environment will be overriden to. 
 - You can switch to another runtime environment.
+- You can reset the environment to its default value.
 
 ## References

--- a/src/app/ApplicationTemplate.Presentation/Configuration/EnvironmentManager.cs
+++ b/src/app/ApplicationTemplate.Presentation/Configuration/EnvironmentManager.cs
@@ -38,9 +38,12 @@ public class EnvironmentManager : IEnvironmentManager
 		Current = File.Exists(_overrideSettingFilePath)
 			? File.ReadAllText(_overrideSettingFilePath)
 			: Default;
+		Next = Current;
 	}
 
-	public string Current { get; private set; }
+	public string Current { get; }
+
+	public string Next { get; private set; }
 
 	public string Default => DefaultEnvironment;
 
@@ -49,6 +52,8 @@ public class EnvironmentManager : IEnvironmentManager
 	public void ClearOverride()
 	{
 		File.Delete(_overrideSettingFilePath);
+
+		Next = Default;
 	}
 
 	public void Override(string environment)
@@ -70,7 +75,7 @@ public class EnvironmentManager : IEnvironmentManager
 			writer.Write(environment);
 		}
 
-		Current = environment;
+		Next = environment;
 	}
 
 	public static string[] GetAll()

--- a/src/app/ApplicationTemplate.Presentation/Configuration/IEnvironmentManager.cs
+++ b/src/app/ApplicationTemplate.Presentation/Configuration/IEnvironmentManager.cs
@@ -15,18 +15,26 @@ public interface IEnvironmentManager
 	string Current { get; }
 
 	/// <summary>
+	/// Gets the next environment that will become the current one when the application restarts.
+	/// </summary>
+	/// <remarks>
+	/// This value changes when using <see cref="Override(string)"/> and <see cref="ClearOverride"/>.
+	/// </remarks>
+	string Next { get; }
+
+	/// <summary>
 	/// Gets the default environment (based on the build variables).
 	/// </summary>
 	string Default { get; }
 
 	/// <summary>
-	/// Overrides the current environment with one provided by <see cref="AvailableEnvironments"/>.
+	/// Overrides the current environment with one provided by <see cref="AvailableEnvironments"/> and sets <see cref="Next"/>.
 	/// </summary>
 	/// <param name="environment">The environment to use as override.</param>
 	void Override(string environment);
 
 	/// <summary>
-	/// Clears the current environment override and returns to the default value.
+	/// Clears the current environment override and set <see cref="Next"/> to the value of <see cref="Default"/>.
 	/// </summary>
 	void ClearOverride();
 

--- a/src/app/ApplicationTemplate.Presentation/ViewModels/Diagnostics/Configuration/ConfigurationDebuggerViewModel.cs
+++ b/src/app/ApplicationTemplate.Presentation/ViewModels/Diagnostics/Configuration/ConfigurationDebuggerViewModel.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Reactive.Disposables;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using Chinook.DynamicMvvm;
 using MessageDialogService;
 using Microsoft.Extensions.Configuration;
@@ -23,10 +25,14 @@ public sealed partial class ConfigurationDebuggerViewModel : TabViewModel
 	private readonly SerialDisposable _changeCallback = new();
 
 	[Inject] private IDiagnosticsService _diagnosticsService;
+	[Inject] private IEnvironmentManager _environmentManager;
 
 	public ConfigurationDebuggerViewModel()
 	{
 		Title = "Configuration";
+		AvailableEnvironments = _environmentManager.AvailableEnvironments;
+		ResetEnvironmentContent = $"Reset to default ({_environmentManager.Default})";
+		CurrentEnvironment = _environmentManager.Current;
 
 		var config = this.GetService<IConfiguration>();
 		UpdateJson(config);
@@ -60,6 +66,15 @@ public sealed partial class ConfigurationDebuggerViewModel : TabViewModel
 		);
 	});
 
+	public IDynamicCommand ResetEnvironment => this.GetCommandFromTask(async ct =>
+	{
+		_environmentManager.ClearOverride();
+		NextEnvironment = _environmentManager.Next;
+
+		// We set the property using the Set method instead of directly using the property to avoid invoking OnSelectedEnvironmentChanged.
+		this.Set(_environmentManager.Default, nameof(SelectedEnvironment));
+	});
+
 	/// <summary>
 	/// Gets the ­­JSON representation of the configuration.
 	/// The JSON has its full hierarchy to look as close as possible to appsettings.json content.
@@ -68,6 +83,39 @@ public sealed partial class ConfigurationDebuggerViewModel : TabViewModel
 	{
 		get => this.Get(initialValue: default(string));
 		private set => this.Set(value);
+	}
+
+	public string CurrentEnvironment { get; }
+
+	public string NextEnvironment
+	{
+		get => this.Get(initialValue: _environmentManager.Next);
+		private set => this.Set(value);
+	}
+
+	public bool IsNextEnvironmentDifferentThanCurrent => this.GetFromDynamicProperty(
+		source: this.GetProperty(x => x.NextEnvironment),
+		selector: next => next != CurrentEnvironment
+	);
+
+	public string ResetEnvironmentContent { get; }
+
+	public string[] AvailableEnvironments { get; }
+
+	public string SelectedEnvironment
+	{
+		get => this.Get(initialValue: _environmentManager.Current);
+		set
+		{
+			this.Set(value);
+			_ = Task.Run(OnSelectedEnvironmentChanged);
+		}
+	}
+
+	private void OnSelectedEnvironmentChanged()
+	{
+		_environmentManager.Override(SelectedEnvironment);
+		NextEnvironment = _environmentManager.Next;
 	}
 
 	private void UpdateJson(IConfiguration config)

--- a/src/app/ApplicationTemplate.Shared.Views/Content/Diagnostics/ConfigurationDebuggerView.xaml
+++ b/src/app/ApplicationTemplate.Shared.Views/Content/Diagnostics/ConfigurationDebuggerView.xaml
@@ -2,6 +2,7 @@
 			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 			 xmlns:local="using:ApplicationTemplate.Views.Content.Diagnostics"
+			 xmlns:nvc="using:Nventive.View.Converters"
 			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 			 xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -13,7 +14,26 @@
 			 d:DesignWidth="400">
 	
 	<UserControl.Resources>
+		<Style x:Key="ConfigurationDebuggerSubtitleStyle"
+			   TargetType="TextBlock">
+			<Setter Property="FontSize"
+					Value="14" />
+			<Setter Property="Foreground"
+					Value="White" />
+			<Setter Property="FontWeight"
+					Value="SemiBold" />
+		</Style>
 		
+		<Style x:Key="ConfigurationDebuggerBodyStyle"
+			   TargetType="TextBlock">
+			<Setter Property="FontSize"
+					Value="12" />
+			<Setter Property="Foreground"
+					Value="White" />
+			<Setter Property="FontWeight"
+					Value="Normal" />
+		</Style>
+
 		<Style x:Key="ConfigurationDebuggerTextBoxStyle"
 			   TargetType="TextBox">
 			<Setter Property="FontSize"
@@ -89,6 +109,9 @@
 			</Setter>
 		</Style>
 
+		<x:String x:Key="UpArrowPathData">M0 0L-5 -5L-10 0H0Z</x:String>
+		<x:String x:Key="DownArrowPathData">M0 0L5 5L10 0H0Z</x:String>
+
 		<Style x:Key="ConfigurationDebuggerButtonStyle"
 			   TargetType="Button">
 
@@ -152,17 +175,333 @@
 			</Setter>
 		</Style>
 
+		<Style x:Key="ConfigurationDebuggerComboBoxItemStyle"
+			   TargetType="ComboBoxItem">
+
+			<Setter Property="Background"
+					Value="Transparent" />
+			<Setter Property="Foreground"
+					Value="White" />
+
+			<Setter Property="FontSize"
+					Value="12" />
+
+			<Setter Property="VerticalContentAlignment"
+					Value="Center" />
+			<Setter Property="HorizontalContentAlignment"
+					Value="Stretch" />
+			<Setter Property="Padding"
+					Value="16,0" />
+			<Setter Property="Height"
+					Value="40" />
+
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="ComboBoxItem">
+						<Grid x:Name="RootGrid"
+							  Background="{TemplateBinding Background}">
+
+							<VisualStateManager.VisualStateGroups>
+								<VisualStateGroup x:Name="CommonStates">
+									<VisualState x:Name="Normal" />
+									<VisualState x:Name="PointerOver" />
+									<VisualState x:Name="Pressed">
+										<VisualState.Setters>
+											<Setter Target="PressedOverlay.Opacity"
+													Value="1" />
+										</VisualState.Setters>
+									</VisualState>
+
+									<VisualState x:Name="Disabled" />
+
+									<VisualState x:Name="Selected">
+										<VisualState.Setters>
+											<Setter Target="PressedOverlay.Opacity"
+													Value="1" />
+										</VisualState.Setters>
+									</VisualState>
+
+									<VisualState x:Name="SelectedPointerOver">
+										<VisualState.Setters>
+											<Setter Target="PressedOverlay.Opacity"
+													Value="1" />
+										</VisualState.Setters>
+									</VisualState>
+
+									<VisualState x:Name="SelectedDisabled" />
+
+									<VisualState x:Name="SelectedPressed">
+										<VisualState.Setters>
+											<Setter Target="PressedOverlay.Opacity"
+													Value="1" />
+										</VisualState.Setters>
+									</VisualState>
+								</VisualStateGroup>
+							</VisualStateManager.VisualStateGroups>
+
+							<!--  Pressed Overlay  -->
+							<Grid x:Name="PressedOverlay"
+								  HorizontalAlignment="Stretch"
+								  VerticalAlignment="Stretch"
+								  Background="#33FFFFFF"
+								  IsHitTestVisible="False"
+								  Opacity="0" />
+
+							<!--  ContentPresenter  -->
+							<ContentPresenter x:Name="ContentPresenter"
+											  Padding="{TemplateBinding Padding}"
+											  Content="{TemplateBinding Content}"
+											  ContentTemplate="{TemplateBinding ContentTemplate}"
+											  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+											  ContentTransitions="{TemplateBinding ContentTransitions}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" />
+						</Grid>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+
+		<Style x:Key="ConfigurationDebuggerComboBoxStyle"
+			   TargetType="ComboBox">
+
+			<Setter Property="Foreground"
+					Value="White" />
+			<Setter Property="Background"
+					Value="#DD000000" />
+			<Setter Property="FontSize"
+					Value="12" />
+			<Setter Property="Padding"
+					Value="4" />
+			
+			<Setter Property="TabNavigation"
+					Value="Once" />
+			<Setter Property="ScrollViewer.HorizontalScrollBarVisibility"
+					Value="Disabled" />
+			<Setter Property="ScrollViewer.VerticalScrollBarVisibility"
+					Value="Auto" />
+			<Setter Property="ScrollViewer.HorizontalScrollMode"
+					Value="Disabled" />
+			<Setter Property="ScrollViewer.VerticalScrollMode"
+					Value="Auto" />
+			<Setter Property="ScrollViewer.IsVerticalRailEnabled"
+					Value="True" />
+			<Setter Property="ScrollViewer.IsDeferredScrollingEnabled"
+					Value="False" />
+			<Setter Property="ScrollViewer.BringIntoViewOnFocusChange"
+					Value="True" />
+			<Setter Property="HorizontalContentAlignment"
+					Value="Stretch" />
+			<Setter Property="HorizontalAlignment"
+					Value="Stretch" />
+
+			<Setter Property="ItemContainerStyle"
+					Value="{StaticResource ConfigurationDebuggerComboBoxItemStyle}" />
+
+			<Setter Property="ItemsPanel">
+				<Setter.Value>
+					<ItemsPanelTemplate>
+						<CarouselPanel />
+					</ItemsPanelTemplate>
+				</Setter.Value>
+			</Setter>
+
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="ComboBox">
+						<Grid x:Name="RootGrid"
+							  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+							  Background="{TemplateBinding Background}"
+							  BorderBrush="{TemplateBinding BorderBrush}"
+							  BorderThickness="{TemplateBinding BorderThickness}">
+							<VisualStateManager.VisualStateGroups>
+								<VisualStateGroup x:Name="CommonStates">
+									<VisualState x:Name="Normal" />
+									<VisualState x:Name="PointerOver" />
+									<VisualState x:Name="Pressed" />
+									<VisualState x:Name="Disabled" />
+								</VisualStateGroup>
+
+								<VisualStateGroup x:Name="DropDownStates">
+
+									<VisualState x:Name="Opened">
+										<VisualState.Setters>
+											<Setter Target="DropDownGlyph_Down.Visibility"
+													Value="Collapsed" />
+											<Setter Target="DropDownGlyph_Up.Visibility"
+													Value="Visible" />
+										</VisualState.Setters>
+										<Storyboard>
+
+											<SplitOpenThemeAnimation ClosedLength="{Binding TemplateSettings.DropDownClosedHeight, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+																	 ClosedTargetName="ContentPresenter"
+																	 ContentTargetName="ScrollViewer"
+																	 ContentTranslationOffset="0"
+																	 OffsetFromCenter="{Binding TemplateSettings.DropDownOffset, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+																	 OpenedLength="{Binding TemplateSettings.DropDownOpenedHeight, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+																	 OpenedTargetName="PopupBorder" />
+										</Storyboard>
+									</VisualState>
+
+									<VisualState x:Name="Closed">
+										<VisualState.Setters>
+											<Setter Target="DropDownGlyph_Down.Visibility"
+													Value="Visible" />
+											<Setter Target="DropDownGlyph_Up.Visibility"
+													Value="Collapsed" />
+										</VisualState.Setters>
+										<Storyboard>
+											<SplitCloseThemeAnimation ClosedLength="{Binding TemplateSettings.DropDownClosedHeight, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+																	  ClosedTargetName="ContentPresenter"
+																	  ContentTargetName="ScrollViewer"
+																	  ContentTranslationDirection="{Binding TemplateSettings.SelectedItemDirection, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+																	  ContentTranslationOffset="40"
+																	  OffsetFromCenter="{Binding TemplateSettings.DropDownOffset, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+																	  OpenedLength="{Binding TemplateSettings.DropDownOpenedHeight, RelativeSource={RelativeSource Mode=TemplatedParent}}"
+																	  OpenedTargetName="PopupBorder" />
+										</Storyboard>
+									</VisualState>
+								</VisualStateGroup>
+							</VisualStateManager.VisualStateGroups>
+
+							<Grid x:Name="ComboBoxContent"
+								  Padding="{TemplateBinding Padding}">
+								<!--<Grid.Resources>
+									--><!--  Resources added here in order to manage the ContentPresenter TranslateY depending if there is a PlaceholderText or not  --><!--
+									<CompositeTransform x:Key="ContentPresenter_CompositeTransformWithPlaceholder"
+														TranslateY="{Binding SelectedItem, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource NullToContentTranslateYConverter}, TargetNullValue=0, FallbackValue=0}" />
+
+									<CompositeTransform x:Key="ContentPresenter_CompositeTransformWithoutPlaceholder"
+														TranslateY="0" />
+
+									<um:FromEmptyStringToValueConverter x:Key="EmptyToCompositeTransformConverter"
+																		NotNullOrEmptyValue="{StaticResource ContentPresenter_CompositeTransformWithPlaceholder}"
+																		NullOrEmptyValue="{StaticResource ContentPresenter_CompositeTransformWithoutPlaceholder}" />
+								</Grid.Resources>-->
+
+								<Grid.ColumnDefinitions>
+									<ColumnDefinition Width="Auto" />
+									<ColumnDefinition Width="*" />
+									<ColumnDefinition Width="Auto" />
+								</Grid.ColumnDefinitions>
+
+								<!--  ContentPresenter  -->
+								<ContentPresenter x:Name="ContentPresenter"
+												  Grid.Column="1"
+												  MaxLines="1"
+												  VerticalAlignment="Center"/>
+
+								<!--  Down  -->
+								<Path x:Name="DropDownGlyph_Down"
+									  Grid.Column="2"
+									  Width="10"
+									  Height="5"
+									  Margin="7,0"
+									  HorizontalAlignment="Center"
+									  VerticalAlignment="Center"
+									  Data="{StaticResource DownArrowPathData}"
+									  Fill="White"
+									  Stretch="Uniform" />
+
+								<!--  Up  -->
+								<Path x:Name="DropDownGlyph_Up"
+									  Grid.Column="2"
+									  Width="10"
+									  Height="5"
+									  Margin="7,0"
+									  HorizontalAlignment="Center"
+									  VerticalAlignment="Center"
+									  Data="{StaticResource UpArrowPathData}"
+									  Fill="White"
+									  Stretch="Uniform"
+									  Visibility="Collapsed" />
+							</Grid>
+
+							<!--  Popup  -->
+							<Popup x:Name="Popup">
+								<Border x:Name="PopupBorder"
+										Background="#DD000000">
+
+									<ScrollViewer x:Name="ScrollViewer"
+												  MinWidth="{ThemeResource ComboBoxPopupThemeMinWidth}"
+												  AutomationProperties.AccessibilityView="Raw"
+												  BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
+												  CornerRadius="{StaticResource MaterialComboBoxCornerRadius}"
+												  HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+												  HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
+												  IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+												  IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
+												  IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
+												  VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+												  VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
+												  VerticalSnapPointsAlignment="Near"
+												  VerticalSnapPointsType="OptionalSingle"
+												  ZoomMode="Disabled">
+										<ItemsPresenter />
+									</ScrollViewer>
+								</Border>
+							</Popup>
+						</Grid>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+
+		<SolidColorBrush x:Key="NormalBrush">White</SolidColorBrush>
+		<SolidColorBrush x:Key="WarningBrush">Yellow</SolidColorBrush>
+
+
+		<nvc:FromNullableBoolToCustomValueConverter x:Key="TrueToYellow"
+													TrueValue="{StaticResource WarningBrush}"
+													NullOrFalseValue="{StaticResource NormalBrush}" />
+
 	</UserControl.Resources>
 
 	<Grid>
 		<ScrollViewer>
 			<StackPanel Margin="0,0,0,200">
+				<!-- Json Configuration --> 
 				<TextBox Text="{Binding ConfigurationAsJson}"
 						 Style="{StaticResource ConfigurationDebuggerTextBoxStyle}" />
 
+				<!-- Clear configuration override button -->
 				<Button Content="Delete configuration override file"
 						Command="{Binding DeleteConfigurationOverride}"
 						Style="{StaticResource ConfigurationDebuggerButtonStyle}"/>
+
+
+				<!-- Environment Editor -->
+
+				<!-- Subtitle -->
+				<TextBlock Text="Environment"
+						   Style="{StaticResource ConfigurationDebuggerSubtitleStyle}"
+						   Margin="0,8,0,0" />
+
+				<!-- Description -->
+				<TextBlock Style="{StaticResource ConfigurationDebuggerBodyStyle}">
+					<Run Text="The app was launched using:" />
+					<Run Text="{Binding CurrentEnvironment}"
+						 Foreground="{Binding IsNextEnvironmentDifferentThanCurrent, Converter={StaticResource TrueToYellow}}" /><Run Text="."/><LineBreak />
+					<Run Text="Upon next launch, it will be:" />
+					<Run Text="{Binding NextEnvironment}"
+						 Foreground="{Binding IsNextEnvironmentDifferentThanCurrent, Converter={StaticResource TrueToYellow}}" /><Run Text="." />
+				</TextBlock>				
+
+				<StackPanel Orientation="Horizontal">
+					<!-- Picker -->
+					<ComboBox ItemsSource="{Binding AvailableEnvironments}"
+							  SelectedItem="{Binding SelectedEnvironment, Mode=TwoWay}"
+							  Style="{StaticResource ConfigurationDebuggerComboBoxStyle}"
+							  Grid.Column="1"
+							  HorizontalAlignment="Left" />
+
+					<!-- Reset Button -->
+					<Button Content="{Binding ResetEnvironmentContent}"
+							Command="{Binding ResetEnvironment}"
+							Style="{StaticResource ConfigurationDebuggerButtonStyle}"
+							Margin="4,0"/>
+
+				</StackPanel>
 			</StackPanel>
 		</ScrollViewer>
 

--- a/src/app/ApplicationTemplate.Tests/Framework/TestEnvironmentManager.cs
+++ b/src/app/ApplicationTemplate.Tests/Framework/TestEnvironmentManager.cs
@@ -19,6 +19,8 @@ public class TestEnvironmentManager : IEnvironmentManager
 
 	public string Current { get; }
 
+	public string Next => Current;
+
 	public string Default { get; }
 
 	public string[] AvailableEnvironments { get; } = new string[] { "DEVELOPMENT", "STAGING", "PRODUCTION" };


### PR DESCRIPTION
…Next to IEnvironmentManager.

GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Feature

## Description

<!-- (Please describe the changes that this PR introduces.) -->
- Add a `Next` property to `IEnvironmentManager` to better understand what the next environment will be when using the override features. And also clarify that `Current` doesn't directly change when using the override features.
- Add controls to the ConfigurationDebuggerView to do the following.
  - Display the current and next environment.
  - Override the environment.
  - Reset the environment to its default value.

![environment2](https://github.com/nventive/UnoApplicationTemplate/assets/39710855/39151ec0-8208-4191-a172-6548ceddb3d6)


## PR Checklist 
Please check if your PR fulfills the following requirements:

- [x] Interface members are XML documented
- [x] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [x] [Architecture documents](./doc/Architecture.md) have been updated
- [x] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->