### PR TITLE
fix(281263): screen reader support for command bar

### DIFF
--- a/src/app/ApplicationTemplate.Shared.Views/Styles/Controls/CommandBar.xaml
+++ b/src/app/ApplicationTemplate.Shared.Views/Styles/Controls/CommandBar.xaml
@@ -130,6 +130,10 @@
 
 		<Setter Property="toolkit:VisibleBoundsPadding.PaddingMask"
 				Value="Top" />
+
+		<!-- This is used so the screen reader doesn't read the page title twice (especially on iOS). -->
+		<Setter Property="AutomationProperties.AccessibilityView"
+				Value="Raw" />
 	</Style>
 
 	<Style x:Key="TransparentCommandBarStyle"


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

## Description

<!-- (Please describe the changes that this PR introduces.) -->
This PR fixes the bug on iOS where the screen reader would read the title in the command bar twice.

## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] ~~Interface members are XML documented~~
- [ ] ~~Documentation (XML or comments) has been added and/or existing documentation has been updated~~
- [ ] ~~[Architecture documents](./doc/Architecture.md) have been updated~~
- [X] Tested on all relevant platforms


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->