### PR TITLE
feat: Add picker for configuration keys.

### DIFF
--- a/src/app/ApplicationTemplate.Shared.Views/Content/Diagnostics/ConfigurationDebuggerView.xaml
+++ b/src/app/ApplicationTemplate.Shared.Views/Content/Diagnostics/ConfigurationDebuggerView.xaml
@@ -483,10 +483,26 @@
 						   Style="{StaticResource ConfigurationDebuggerSubtitleStyle}"
 						   Margin="0,4,0,0" />
 
-				<!-- Configuration Key Input -->
-				<TextBox Text="{Binding ConfigurationKey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-						 Style="{StaticResource ConfigurationDebuggerTextBoxStyle}"
-						 Padding="4,8"/>
+				<Grid Margin="0,2,4,0">
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="*" />
+						<ColumnDefinition Width="Auto" />
+					</Grid.ColumnDefinitions>
+					
+					<!-- Configuration Key Input -->
+					<TextBox Text="{Binding ConfigurationKey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+							 Style="{StaticResource ConfigurationDebuggerTextBoxStyle}"
+							 Padding="4,8" />
+
+					<!-- Picker for existing keys -->
+					<ComboBox ItemsSource="{Binding AllKeys}"
+							  SelectedItem="{Binding SelectedKey, Mode=TwoWay}"
+							  Style="{StaticResource ConfigurationDebuggerComboBoxStyle}"
+							  Grid.Column="1"
+							  Height="30"
+							  Width="40"
+							  Margin="2,0,0,0"/>
+				</Grid>
 
 				<Grid Margin="0,2,4,0">
 					<Grid.ColumnDefinitions>
@@ -504,6 +520,7 @@
 							Command="{Binding Save}"
 							Style="{StaticResource ConfigurationDebuggerButtonStyle}"							
 							Grid.Column="1"
+							Width="40"
 							Margin="2,0,0,0"/>
 				</Grid>
 


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Feature

## Description

<!-- (Please describe the changes that this PR introduces.) -->
Add ComboBox in the ConfigurationDebuggerView to quickly pick a configuration key in the editor.

![config-quick-edit](https://github.com/nventive/UnoApplicationTemplate/assets/39710855/c7c4742e-068e-4fe9-a79b-3488d40a57a3)

## PR Checklist 
Please check if your PR fulfills the following requirements:

- [x] Interface members are XML documented
- [x] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [ ] Tested on all relevant platforms
- [x] TODO comments are hints for next steps for users of the template and not planned work.


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->