### PR TITLE
feat: Add options to move the diagnostics overlay left and right.

### DIFF
--- a/src/app/ApplicationTemplate.Presentation/Configuration/DiagnosticsConfiguration.cs
+++ b/src/app/ApplicationTemplate.Presentation/Configuration/DiagnosticsConfiguration.cs
@@ -39,6 +39,8 @@ public class DiagnosticsOptions
 
 	public bool IsDiagnosticsOverlayEnabled { get; set; }
 
+	public bool IsDiagnosticsOverlayOnTheLeft { get; set; }
+
 	public bool IsHttpDebuggerEnabled { get; set; }
 
 	public HttpDebuggerOptions HttpDebugger { get; set; } = new();

--- a/src/app/ApplicationTemplate.Presentation/ViewModels/Diagnostics/DiagnosticsOverlayViewModel.cs
+++ b/src/app/ApplicationTemplate.Presentation/ViewModels/Diagnostics/DiagnosticsOverlayViewModel.cs
@@ -84,13 +84,6 @@ public sealed partial class DiagnosticsOverlayViewModel : ViewModel
 		);
 	}
 
-	public IDynamicCommand ToggleHttpDebugger => this.GetCommand(() =>
-	{
-		// The HttpDebugger is currently the only thing in the expanded view.
-		// This method will change when we add more things to the expanded view.
-		IsDiagnosticsExpanded = !IsDiagnosticsExpanded;
-	});
-
 	public bool IsDiagnosticsExpanded
 	{
 		get => this.Get<bool>();
@@ -116,9 +109,46 @@ public sealed partial class DiagnosticsOverlayViewModel : ViewModel
 		}
 	}
 
+	public bool IsOverlayOnTheLeft
+	{
+		get => this.GetFromOptionsMonitor<DiagnosticsOptions, bool>(o => o.IsDiagnosticsOverlayOnTheLeft);
+		set => this.Set(value);
+	}
+
+	/// <summary>
+	/// Gets the VisualState name of the DiagnosticsOverlay.
+	/// </summary>
+	public string OverlayState => this.GetFromObservable(ObserveOverlayState(), initialValue: "MinimizedRight");
+
+	private IObservable<string> ObserveOverlayState()
+	{
+		return Observable.CombineLatest(
+			this.GetProperty(x => x.IsDiagnosticsExpanded).GetAndObserve(),
+			this.GetProperty(x => x.IsOverlayOnTheLeft).GetAndObserve(),
+			(isExpanded, isLeft) =>
+			{
+				if (isExpanded)
+				{
+					return "Expanded";
+				}
+
+				if (isLeft)
+				{
+					return "MinimizedLeft";
+				}
+
+				return "MinimizedRight";
+			});
+	}
+
 	public IDynamicCommand ToggleMore => this.GetCommand(() =>
 	{
 		IsDiagnosticsExpanded = !IsDiagnosticsExpanded;
+	});
+
+	public IDynamicCommand ToggleSide => this.GetCommand(() =>
+	{
+		IsOverlayOnTheLeft = !IsOverlayOnTheLeft;
 	});
 
 	public CountersData Counters => this.GetFromObservable(ObserveCounters, DiagnosticsCountersService.Counters);

--- a/src/app/ApplicationTemplate.Shared.Views/Content/Diagnostics/DiagnosticsOverlay.xaml
+++ b/src/app/ApplicationTemplate.Shared.Views/Content/Diagnostics/DiagnosticsOverlay.xaml
@@ -3,28 +3,15 @@
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 			 xmlns:uc="using:Nventive.View.Converters"
+			 xmlns:nve="using:Nventive.View.Extensions"
 			 xmlns:diag="using:ApplicationTemplate.Views.Content.Diagnostics"
 			 xmlns:xamarin="http://uno.ui/xamarin"
 			 xmlns:not_ios="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-			 mc:Ignorable="xamarin">
+			 mc:Ignorable="xamarin"
+			 nve:BindableVisualState.VisualStateName="{Binding OverlayState}">
 
 	<UserControl.Resources>
 		<ResourceDictionary>
-
-			<!-- True to HorizontalStretch -->
-			<uc:FromNullableBoolToCustomValueConverter x:Key="TrueToHorizontalStretch"
-													   TrueValue="Stretch"
-													   NullOrFalseValue="Right" />
-
-			<!-- True to VerticalStretch -->
-			<uc:FromNullableBoolToCustomValueConverter x:Key="TrueToVerticalStretch"
-													   TrueValue="Stretch"
-													   NullOrFalseValue="Top" />
-
-			<!-- IsExpanded to CornerRadius -->
-			<uc:FromNullableBoolToCustomValueConverter x:Key="IsExpandedToCornerRadius"
-													   TrueValue="0"
-													   NullOrFalseValue="8,0,0,8" />
 
 			<!-- Diagnostics Counter TextBlockStyle -->
 			<Style x:Key="DiagnosticsCounterTextBlockStyle"
@@ -254,12 +241,41 @@
 	</UserControl.Resources>
 
 	<Grid>
-		<Grid Background="#AA000000"
+		<VisualStateManager.VisualStateGroups>
+			<VisualStateGroup x:Name="ExpandStates">
+				<VisualState x:Name="MinimizedRight" />
+				<VisualState x:Name="MinimizedLeft">
+					<VisualState.Setters>
+						<Setter Target="RootGrid.CornerRadius"
+								Value="0,8,8,0" />
+						<Setter Target="RootGrid.HorizontalAlignment"
+								Value="Left" />
+					</VisualState.Setters>
+				</VisualState>
+				<VisualState x:Name="Expanded">
+					<VisualState.Setters>
+						<Setter Target="RootGrid.CornerRadius"
+								Value="0" />
+						<Setter Target="RootGrid.HorizontalAlignment"
+								Value="Stretch" />
+						<Setter Target="RootGrid.VerticalAlignment"
+								Value="Stretch" />
+						<Setter Target="ExpandedContainerGrid.Visibility"
+								Value="Visible" />
+						<Setter Target="ExpandButton.Content"
+								Value="Minimize" />
+					</VisualState.Setters>
+				</VisualState>
+			</VisualStateGroup>
+		</VisualStateManager.VisualStateGroups>
+		
+		<Grid x:Name="RootGrid"
+			  Background="#AA000000"
 			  BorderThickness="1"
 			  BorderBrush="#000000"
-			  CornerRadius="{Binding IsDiagnosticsExpanded, Converter={StaticResource IsExpandedToCornerRadius}}"
-			  HorizontalAlignment="{Binding IsDiagnosticsExpanded, Converter={StaticResource TrueToHorizontalStretch}, FallbackValue=Right}"
-			  VerticalAlignment="{Binding IsDiagnosticsExpanded, Converter={StaticResource TrueToVerticalStretch}, FallbackValue=Top}"
+			  CornerRadius="8,0,0,8"
+			  HorizontalAlignment="Right"
+			  VerticalAlignment="Top"
 			  Padding="0"
 			  Margin="0,100,0,0">
 
@@ -399,7 +415,8 @@
 			</StackPanel>
 
 			<!-- Diagnostics expanded content -->
-			<Grid Visibility="{Binding IsDiagnosticsExpanded, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}"
+			<Grid x:Name="ExpandedContainerGrid"
+				  Visibility="Collapsed"
 				  Grid.Row="0"
 				  Grid.RowSpan="3"
 				  Padding="0,0,50,0">
@@ -439,30 +456,21 @@
 						Command="{Binding CollectMemory}"
 						Style="{StaticResource DiagnosticsOverlayButtonStyle}" />
 
-				<!-- Toggle Http Debugger Button -->
-				<Button Content="Http"
-						Command="{Binding ToggleHttpDebugger}"
-						Style="{StaticResource DiagnosticsOverlayButtonStyle}" />
-
 				<!-- Theme Button -->
 				<Button Content="Theme"
 						Click="OnThemeButtonClicked"
 						Style="{StaticResource DiagnosticsOverlayButtonStyle}" />
 
 				<!-- More Button -->
-				<Button Command="{Binding ToggleMore}"
-						Style="{StaticResource DiagnosticsOverlayButtonStyle}">
-					<Grid>
+				<Button x:Name="ExpandButton"
+						Content="Expand"
+						Command="{Binding ToggleMore}"
+						Style="{StaticResource DiagnosticsOverlayButtonStyle}" />
 
-						<!-- Not Expended Content -->
-						<TextBlock Text="&lt;"
-								   Visibility="{Binding IsDiagnosticsExpanded, Converter={StaticResource TrueToCollapsed}, FallbackValue=Collapsed}" />
-
-						<!-- Expended Content -->
-						<TextBlock Text=">"
-								   Visibility="{Binding IsDiagnosticsExpanded, Converter={StaticResource TrueToVisible}, FallbackValue=Collapsed}" />
-					</Grid>
-				</Button>
+				<!-- Move Button -->
+				<Button Content="Move"
+						Command="{Binding ToggleSide}"
+						Style="{StaticResource DiagnosticsOverlayButtonStyle}" />
 
 				<!-- Close Button -->
 				<Button Content="X"


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Feature

## Description

<!-- (Please describe the changes that this PR introduces.) -->

Add option to move the diagnostics overlay left and right.
This is useful when the overlay is obscuring important parts of the UI.

![overlay-move](https://github.com/nventive/UnoApplicationTemplate/assets/39710855/c3632b9d-2470-481d-92f5-15b71a819fff)

## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [x] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [x] Tested on all relevant platforms
- [x] TODO comments are hints for next steps for users of the template and not planned work.


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->