### PR TITLE
fix: Add stable tag to versions from main to prevent build issue.

### DIFF
--- a/.template.config/build/gitversion-config.yml
+++ b/.template.config/build/gitversion-config.yml
@@ -14,7 +14,7 @@ no-bump-message: "^(ci)(\\([\\w\\s-]*\\))?:" # You can use the "ci" type to avoi
 branches:
   main:
     regex: ^master$|^main$
-    tag: ''
+    tag: 'stable'
   dev:
     regex: dev/.*?/(.*?)
     tag: dev.{BranchName}

--- a/.template.config/build/stage-publish-template.yml
+++ b/.template.config/build/stage-publish-template.yml
@@ -13,7 +13,7 @@ jobs:
       arguments: > 
         pack $(Build.SourcesDirectory)/.template.config/build/NV.Templates.Mobile.nuspec
         -NoDefaultExcludes
-        -Version $(GitVersion.SemVer)
+        -Version $(GitVersion.MajorMinorPatch)
         -OutputDirectory $(Build.ArtifactStagingDirectory)
 
   - publish: $(Build.ArtifactStagingDirectory)

--- a/build/templates/gitversion.yml
+++ b/build/templates/gitversion.yml
@@ -11,7 +11,7 @@ steps:
     inputs:
       useConfigFile: true
       configFilePath: $(Build.SourcesDirectory)/.template.config/build/gitversion-config.yml
-    displayName: 'Calculate Version'
+    displayName: 'Calculate Template Version'
 #-endif
 
   - task: gitversion/execute@0
@@ -22,4 +22,4 @@ steps:
     inputs:
       useConfigFile: true
       configFilePath: $(Build.SourcesDirectory)/gitversion-config.yml
-    displayName: 'Calculate Version'
+    displayName: 'Calculate App Version'


### PR DESCRIPTION
GitHub Issue: #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
- Build or CI related changes

## Description

<!-- (Please describe the changes that this PR introduces.) -->

Add `stable` tag to informational versions of builds from the main branch to prevent a build issue on Android and iOS.


## PR Checklist 
Please check if your PR fulfills the following requirements:

- [ ] Interface members are XML documented
- [x] Documentation (XML or comments) has been added and/or existing documentation has been updated
- [ ] [Architecture documents](./doc/Architecture.md) have been updated
- [ ] Tested on all relevant platforms
- [x] TODO comments are hints for next steps for users of the template and not planned work.


## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->