### PR TITLE
feat: Turn on warning as errors for layer libs and update analyzers.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-root = true
+﻿root = true
 
 #############################
 # Core EditorConfig Options #
@@ -42,7 +42,7 @@ dotnet_sort_system_directives_first = true
 dotnet_separate_import_directive_groups = false
 
 # Use C#10 file-scoped namespaces
-csharp_style_namespace_declarations=file_scoped:suggestion
+csharp_style_namespace_declarations = file_scoped:suggestion
 
 # Avoid the this. keyword
 dotnet_style_qualification_for_field = false:suggestion
@@ -67,6 +67,9 @@ dotnet_style_prefer_auto_properties = true:suggestion
 dotnet_style_prefer_conditional_expression_over_assignment = true:suggestion
 dotnet_style_prefer_conditional_expression_over_return = true:suggestion
 
+# Operator placement
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+
 # Parentheses preferences
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:suggestion
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:suggestion
@@ -87,7 +90,7 @@ dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 # Constant fields are PascalCase
 dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style = non_private_static_field_style
 dotnet_naming_symbols.constant_fields.applicable_kinds = field
 dotnet_naming_symbols.constant_fields.applicable_accessibilities = *
 dotnet_naming_symbols.constant_fields.required_modifiers = const
@@ -95,7 +98,7 @@ dotnet_naming_symbols.constant_fields.required_modifiers = const
 # Non-private readonly fields are PascalCase
 dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.symbols = non_private_readonly_fields
-dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.style = non_private_readonly_field_style
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.style = non_private_static_field_style
 dotnet_naming_symbols.non_private_readonly_fields.applicable_kinds = field
 dotnet_naming_symbols.non_private_readonly_fields.applicable_accessibilities = public, protected, internal, protected internal, private protected
 dotnet_naming_symbols.non_private_readonly_fields.required_modifiers = readonly
@@ -113,7 +116,7 @@ dotnet_naming_style.non_private_static_field_style.capitalization = pascal_case
 # Private static fields are camelCase
 dotnet_naming_rule.static_fields_should_be_camel_case.severity = suggestion
 dotnet_naming_rule.static_fields_should_be_camel_case.symbols = static_fields
-dotnet_naming_rule.static_fields_should_be_camel_case.style = static_field_style
+dotnet_naming_rule.static_fields_should_be_camel_case.style = instance_field_style
 dotnet_naming_symbols.static_fields.applicable_kinds = field
 dotnet_naming_symbols.static_fields.required_modifiers = static
 dotnet_naming_style.static_field_style.capitalization = camel_case
@@ -137,20 +140,50 @@ dotnet_naming_style.camel_case_style.capitalization = camel_case
 # Local functions are PascalCase
 dotnet_naming_rule.local_functions_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.local_functions_should_be_pascal_case.symbols = local_functions
-dotnet_naming_rule.local_functions_should_be_pascal_case.style = local_function_style
+dotnet_naming_rule.local_functions_should_be_pascal_case.style = non_private_static_field_style
 dotnet_naming_symbols.local_functions.applicable_kinds = local_function
 dotnet_naming_style.local_function_style.capitalization = pascal_case
 
 # By default, name items with PascalCase
 dotnet_naming_rule.members_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.members_should_be_pascal_case.symbols = all_members
-dotnet_naming_rule.members_should_be_pascal_case.style = pascal_case_style
+dotnet_naming_rule.members_should_be_pascal_case.style = non_private_static_field_style
 dotnet_naming_symbols.all_members.applicable_kinds = *
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
 #######################
 # C# Code Style Rules #
 #######################
+
+csharp_using_directive_placement = outside_namespace:silent
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = true:silent
+csharp_style_throw_expression = true:suggestion
+csharp_style_prefer_null_check_over_type_check = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_prefer_utf8_string_literals = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+csharp_prefer_static_local_function = true:suggestion
+csharp_style_prefer_readonly_struct = true:suggestion
+csharp_style_prefer_readonly_struct_member = true:suggestion
+csharp_style_allow_embedded_statements_on_same_line_experimental = true:silent
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true:silent
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true:silent
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = true:silent
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true:silent
+csharp_style_conditional_delegate_call = true:suggestion
+csharp_style_prefer_switch_expression = true:suggestion
+csharp_style_prefer_pattern_matching = true:suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_prefer_not_pattern = true:suggestion
+csharp_style_prefer_extended_property_pattern = true:suggestion
 
 # Indentation preferences
 csharp_indent_block_contents = true
@@ -167,11 +200,13 @@ csharp_style_var_elsewhere = true:suggestion
 
 # Prefer property-like constructs to have an expression-body
 csharp_style_expression_bodied_properties = true:suggestion
-csharp_style_expression_bodied_indexers = true:suggestion
-csharp_style_expression_bodied_accessors = true:suggestion
+csharp_style_expression_bodied_indexers = when_on_single_line:suggestion
+csharp_style_expression_bodied_accessors = when_on_single_line:suggestion
 csharp_style_expression_bodied_methods = false:none
 csharp_style_expression_bodied_constructors = false:none
 csharp_style_expression_bodied_operators = false:none
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_expression_bodied_lambdas = when_on_single_line:silent
 
 # Newline preferences
 csharp_new_line_before_open_brace = all
@@ -200,6 +235,17 @@ csharp_space_around_binary_operators = before_and_after
 csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
 csharp_space_between_method_call_name_and_opening_parenthesis = false
 csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_after_comma = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_around_declaration_statements = false
+csharp_space_before_open_square_brackets = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_square_brackets = false
+csharp_space_after_dot = false
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_semicolon_in_for_statement = false
 
 # Blocks are allowed
 csharp_prefer_braces = true:suggestion
@@ -266,7 +312,7 @@ dotnet_diagnostic.SA1202.severity = suggestion
 # SA1600:Elements should be documented
 dotnet_diagnostic.SA1600.severity = none
 # SA1601:Elements should be documented
-dotnet_diagnostic.SA1601.severity = none
+dotnet_diagnostic.SA1601.severity = suggestion
 # SA1116:Split parameters should start on line after declaration
 dotnet_diagnostic.SA1116.severity = none
 # SA1111:Closing parenthesis should be on line of last parameter
@@ -331,3 +377,17 @@ dotnet_diagnostic.CA1024.severity = none
 dotnet_diagnostic.SA1615.severity = suggestion
 # CA5394: Do not use insecure randomness
 dotnet_diagnostic.CA5394.severity = suggestion
+# SA1623: Property summary documentation should match accessors
+dotnet_diagnostic.SA1623.severity = suggestion
+# SA1502: Element should not be on a single line
+dotnet_diagnostic.SA1502.severity = suggestion
+# SA1602: Enumeration items should be documented
+dotnet_diagnostic.SA1602.severity = suggestion
+# CA1032: Implement standard exception constructors
+dotnet_diagnostic.CA1032.severity = suggestion
+# SA1210: Using directives must be ordered alphabetically by namespace
+dotnet_diagnostic.SA1210.severity = suggestion
+# CA1308: Normalize strings to uppercase
+dotnet_diagnostic.CA1308.severity = none
+# CS1587: XML comment is not placed on a valid language element
+dotnet_diagnostic.CS1587.severity = none

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 Prefix your items with `(Template)` if the change is about the template and not the resulting application.
 
+## 2.1.X
+- Enable `TreatWarningsAsErrors` for the Access, Business, and Presentation projects.
+- Update analyzers packages and severity of rules.
+
 ## 2.0.X
 - Renamed the classes providing data to use the `Repository` suffix instead of `Endpoint` or `Service`.
 - Renamed the Client library to Access.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,10 +1,10 @@
 ﻿<Project>
 	<ItemGroup>
-		<PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
+		<PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/app/ApplicationTemplate.Access/ApplicationTemplate.Access.csproj
+++ b/src/app/ApplicationTemplate.Access/ApplicationTemplate.Access.csproj
@@ -4,6 +4,8 @@
 		<TargetFramework>net7.0</TargetFramework>
 		<LangVersion>11.0</LangVersion>
 		<RootNamespace>ApplicationTemplate.DataAccess</RootNamespace>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<TreatWarningsAsErrors Condition="'$(Configuration)'=='Release'">true</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/app/ApplicationTemplate.Access/Framework/BaseMock.cs
+++ b/src/app/ApplicationTemplate.Access/Framework/BaseMock.cs
@@ -28,7 +28,6 @@ public class BaseMock
 	/// <returns>Deserialized value</returns>
 	/// <remarks>
 	/// If left empty, the <paramref name="resourceName" /> will implicitly be treated as "{callerTypeName}.{callerMemberName}.json".
-	/// If <paramref name="serializer" /> is left empty, the serializer defined in ctor. will be used".
 	/// Note that this will deserialize the first embedded resource whose name ends with the specified <paramref name="resourceName" />.
 	/// </remarks>
 	[System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1307:Specify StringComparison", Justification = "Not available for Desktop")]
@@ -62,7 +61,6 @@ public class BaseMock
 	/// </summary>
 	/// <remarks>
 	/// If left empty, the <paramref name="resourceName" /> will implicitly be treated as "{callerTypeName}.{callerMemberName}.json".
-	/// If <paramref name="serializer" /> is left empty, the serializer defined in ctor. will be used".
 	/// Note that this will deserialize the first embedded resource whose name ends with the specified <paramref name="resourceName" />.
 	/// </remarks>
 	/// <typeparam name="T">Type of object</typeparam>

--- a/src/app/ApplicationTemplate.Access/Framework/Configuration/IConfiguration.Extensions.cs
+++ b/src/app/ApplicationTemplate.Access/Framework/Configuration/IConfiguration.Extensions.cs
@@ -14,7 +14,7 @@ public static class ApplicationTemplateConfigurationExtensions
 {
 	/// <summary>
 	/// Returns the <see cref="IConfigurationSection"/> for the options represented by <typeparamref name="T"/>.
-	/// The section name is either the options type name (minus the -Options prefix) or <paramref name="key"/>, if provided.
+	/// The section name is either the options type name (minus the -Options suffix) or <paramref name="key"/>, if provided.
 	/// <see cref="DefaultOptionsName{T}"/> as well.
 	/// </summary>
 	/// <typeparam name="T">The options type.</typeparam>
@@ -28,7 +28,7 @@ public static class ApplicationTemplateConfigurationExtensions
 
 	/// <summary>
 	/// Reads the current value for options.
-	/// The section name is either the options type name (minus the -Options prefix) or <paramref name="key"/>, if provided.
+	/// The section name is either the options type name (minus the -Options suffix) or <paramref name="key"/>, if provided.
 	/// <see cref="DefaultOptionsName{T}"/> as well.
 	/// </summary>
 	/// <typeparam name="T">The options type.</typeparam>
@@ -44,19 +44,21 @@ public static class ApplicationTemplateConfigurationExtensions
 
 	/// <summary>
 	/// Gets the default name for options of type <paramref name="optionsType"/>.
-	/// Removes the -Options prefix if any.
+	/// Removes the -Options suffix if any.
 	/// </summary>
+	/// <param name="optionsType">The type from which to extract a default options name.</param>
 	public static string DefaultOptionsName(Type optionsType) => DefaultOptionsName(optionsType.Name);
 
 	/// <summary>
 	/// Gets the default name for options of the specified <paramref name="optionsTypeName"/>.
-	/// Removes the -Options prefix if any.
+	/// Removes the -Options suffix if any.
 	/// </summary>
+	/// <param name="optionsTypeName">The name of the type from which to extract a default options name.</param>
 	public static string DefaultOptionsName(string optionsTypeName) => Regex.Replace(optionsTypeName, @"Options$", string.Empty);
 
 	/// <summary>
 	/// Gets the default name for options of type <typeparamref name="T"/>.
-	/// Removes the -Options prefix if any.
+	/// Removes the -Options suffix if any.
 	/// </summary>
 	/// <typeparam name="T">The Options type.</typeparam>
 	public static string DefaultOptionsName<T>() => DefaultOptionsName(typeof(T));

--- a/src/app/ApplicationTemplate.Access/Framework/Configuration/IServiceCollection.Extensions.cs
+++ b/src/app/ApplicationTemplate.Access/Framework/Configuration/IServiceCollection.Extensions.cs
@@ -17,7 +17,7 @@ public static class ApplicationTemplateServiceCollectionExtensions
 {
 	/// <summary>
 	/// Registers <typeparamref name="T"/> as an option bound to the <paramref name="configuration"/>
-	/// using the typename as key (minus the -Options prefix).
+	/// using the type name as key (minus the -Options suffix).
 	/// The validation, based on Data Annotations, happens when options are retrieved from DI,
 	/// not at the time of registration.
 	/// </summary>
@@ -26,8 +26,8 @@ public static class ApplicationTemplateServiceCollectionExtensions
 	/// <param name="configuration">The <see cref="IConfiguration"/>.</param>
 	/// <param name="key">
 	/// The configuration section key name to use.
-	/// If not provided, it will be the <typeparamref name="T"/> type name without the -Options prefix.
-	/// (see <see cref="ConfigurationExtensions.DefaultOptionsName(Type)"/>.
+	/// If not provided, it will be the <typeparamref name="T"/> type name without the -Options suffix.
+	/// (see <see cref="ApplicationTemplateConfigurationExtensions.DefaultOptionsName(Type)"/>.
 	/// </param>
 	/// <returns>The <see cref="IServiceCollection"/> with services registered.</returns>
 	public static IServiceCollection BindOptionsToConfiguration<T>(

--- a/src/app/ApplicationTemplate.Access/Framework/HttpDebugger/HttpDebuggerHandler.cs
+++ b/src/app/ApplicationTemplate.Access/Framework/HttpDebugger/HttpDebuggerHandler.cs
@@ -34,7 +34,7 @@ public class HttpDebuggerHandler : DelegatingHandler
 				ResponseVersion = response.Version,
 				ResponseHeaders = response.Headers,
 				ResponseContentHeaders = response.Content.Headers,
-				ResponseContent = await response.Content.ReadAsStringAsync(),
+				ResponseContent = await response.Content.ReadAsStringAsync(CancellationToken.None),
 			});
 
 			return response;

--- a/src/app/ApplicationTemplate.Access/Framework/Serialization/JwtData.cs
+++ b/src/app/ApplicationTemplate.Access/Framework/Serialization/JwtData.cs
@@ -18,10 +18,10 @@ public class JwtData<TPayload>
 	private TPayload _payload;
 
 	/// <summary>
-	/// Initialize a new JWT.
+	/// Initializes a new instance of the <see cref="JwtData{TPayload}"/> class.
 	/// </summary>
 	/// <remarks>
-	/// Header & Payload will be deserialized only if a JSON serializer is supplied.
+	/// Header and Payload will be deserialized only if a JSON serializer is supplied.
 	/// </remarks>
 	/// <param name="token">The raw token.</param>
 	/// <param name="jsonSerializerOptions">Should be a JSON serializer. Using a serializer for another format won't be RFC 7519 compliant.</param>

--- a/src/app/ApplicationTemplate.Business/ApplicationTemplate.Business.csproj
+++ b/src/app/ApplicationTemplate.Business/ApplicationTemplate.Business.csproj
@@ -2,6 +2,8 @@
 	<PropertyGroup>
 		<TargetFramework>net7.0</TargetFramework>
 		<LangVersion>11.0</LangVersion>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<TreatWarningsAsErrors Condition="'$(Configuration)'=='Release'">true</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/app/ApplicationTemplate.Business/Posts/IPostService.cs
+++ b/src/app/ApplicationTemplate.Business/Posts/IPostService.cs
@@ -35,8 +35,8 @@ public interface IPostService
 	/// </summary>
 	/// <param name="ct"><see cref="CancellationToken"/></param>
 	/// <param name="postId">Post id</param>
-	/// <param name="post"><see cref="PostData"/></param>
-	/// <returns>Updated <see cref="PostData"/></returns>
+	/// <param name="post"><see cref="Post"/></param>
+	/// <returns>Updated <see cref="Post"/></returns>
 	Task<Post> Update(CancellationToken ct, long postId, Post post);
 
 	/// <summary>

--- a/src/app/ApplicationTemplate.Presentation/ApplicationTemplate.Presentation.csproj
+++ b/src/app/ApplicationTemplate.Presentation/ApplicationTemplate.Presentation.csproj
@@ -3,6 +3,8 @@
 	<PropertyGroup>
 		<TargetFramework>net7.0</TargetFramework>
 		<LangVersion>11.0</LangVersion>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<TreatWarningsAsErrors Condition="'$(Configuration)'=='Release'">true</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/app/ApplicationTemplate.Presentation/Configuration/ApiConfiguration.cs
+++ b/src/app/ApplicationTemplate.Presentation/Configuration/ApiConfiguration.cs
@@ -1,11 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Net.Http;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
-using ApplicationTemplate;
 using ApplicationTemplate.Business;
 using ApplicationTemplate.DataAccess;
 using MallardMessageHandlers;

--- a/src/app/ApplicationTemplate.Presentation/Configuration/ConfigurationConfiguration.cs
+++ b/src/app/ApplicationTemplate.Presentation/Configuration/ConfigurationConfiguration.cs
@@ -56,6 +56,7 @@ public static class ConfigurationConfiguration
 	/// </summary>
 	/// <param name="configurationBuilder">The configuration builder.</param>
 	/// <param name="folderPath">The folder containing the configuration override files.</param>
+	/// <param name="environmentManager">The environment manager.</param>
 	private static IConfigurationBuilder AddReadOnlyConfiguration(this IConfigurationBuilder configurationBuilder, string folderPath, IEnvironmentManager environmentManager)
 	{
 		return configurationBuilder.AddInMemoryCollection(GetCodeConfiguration(folderPath));
@@ -91,6 +92,7 @@ public static class ConfigurationConfiguration
 	/// The environment can be overriden by the user.
 	/// </summary>
 	/// <param name="configurationBuilder">The configuration builder.</param>
+	/// <param name="environmentManager">The environment manager.</param>
 	private static IConfigurationBuilder AddEnvironmentConfiguration(this IConfigurationBuilder configurationBuilder, IEnvironmentManager environmentManager)
 	{
 		var currentEnvironment = environmentManager.Current;
@@ -119,6 +121,7 @@ public static class ConfigurationConfiguration
 	/// Registers the <see cref="IConfiguration"/> as a singleton.
 	/// </summary>
 	/// <param name="hostBuilder">The host builder.</param>
+	/// <param name="environmentManager">The environment manager.</param>
 	private static IHostBuilder AddConfiguration(this IHostBuilder hostBuilder, IEnvironmentManager environmentManager)
 	{
 		if (hostBuilder is null)
@@ -190,7 +193,7 @@ public static class ConfigurationConfiguration
 
 				_appSettingsFiles = executingAssembly
 					.GetManifestResourceNames()
-					.Where(fileName => fileName.ToUpperInvariant().Contains(AppSettingsFileName.ToUpperInvariant()))
+					.Where(fileName => fileName.ToUpperInvariant().Contains(AppSettingsFileName.ToUpperInvariant(), StringComparison.Ordinal))
 					.Select(fileName => new AppSettingsFile(fileName, executingAssembly))
 					.ToArray();
 			}

--- a/src/app/ApplicationTemplate.Presentation/Configuration/ReviewConfiguration.cs
+++ b/src/app/ApplicationTemplate.Presentation/Configuration/ReviewConfiguration.cs
@@ -37,6 +37,7 @@ public static class ReviewConfiguration
 			.AddSingleton<IReviewService, ReviewServiceAdapter>();
 	}
 
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The constructor is invoked by DI.")]
 	private sealed class ReviewServiceAdapter : IReviewService
 	{
 		private readonly IReviewService<ReviewSettings> _reviewService;

--- a/src/app/ApplicationTemplate.Presentation/Framework/Connectivity/MockedConnectivityProvider.cs
+++ b/src/app/ApplicationTemplate.Presentation/Framework/Connectivity/MockedConnectivityProvider.cs
@@ -29,6 +29,6 @@ public sealed class MockedConnectivityProvider : IConnectivityProvider
 			ConnectivityChanged?.Invoke(this, new ConnectivityChangedEventArgs(value));
 		}
 	}
-	
+
 	public event EventHandler<ConnectivityChangedEventArgs> ConnectivityChanged;
 }

--- a/src/app/ApplicationTemplate.Presentation/Framework/DataLoader/NetworkReconnectionDataLoaderTrigger.cs
+++ b/src/app/ApplicationTemplate.Presentation/Framework/DataLoader/NetworkReconnectionDataLoaderTrigger.cs
@@ -22,9 +22,11 @@ public sealed class NetworkReconnectionDataLoaderTrigger : DataLoaderTriggerBase
 		_connectivity.ConnectivityChanged += OnConnectivityChanged;
 	}
 
+	/// <remarks>
+	/// We should only refresh when <see cref="IDataLoader" /> state is <see cref="NoNetworkException"/> AND network access is <see cref="NetworkAccess.Internet"/>.
+	/// </remarks>
 	private void OnConnectivityChanged(object sender, ConnectivityChangedEventArgs e)
 	{
-		/// Should only refresh when <see cref="IDataLoader" /> state is <see cref="NoNetworkException"/> AND network access is <see cref="NetworkAccess.Internet"/>.
 		if (_dataLoader.State.Error is NoNetworkException &&
 			e.NetworkAccess == NetworkAccess.Internet)
 		{

--- a/src/app/ApplicationTemplate.Presentation/Framework/Startup/StartupBase.cs
+++ b/src/app/ApplicationTemplate.Presentation/Framework/Startup/StartupBase.cs
@@ -10,7 +10,7 @@ namespace ApplicationTemplate;
 /// <summary>
 /// This class abstracts the startup of the actual app (UWP, iOS, Android and not test projects).
 /// This abstract class is responsible for building the host of the application as well as startup diagnostics.
-/// The implementator class is responsible for the application-specific code that initializes the application's services.
+/// The implementer class is responsible for the application-specific code that initializes the application's services.
 /// </summary>
 public abstract class StartupBase
 {
@@ -61,6 +61,8 @@ public abstract class StartupBase
 	/// Initializes the application.
 	/// </summary>
 	/// <param name="contentRootPath">Specifies the content root directory to be used by the host.</param>
+	/// <param name="settingsFolderPath">The folder path indicating where the override files are.</param>
+	/// <param name="loggingConfigurator">The delegate to call to configure logging.</param>
 	public void Initialize(string contentRootPath, string settingsFolderPath, LoggingConfigurator­­­ loggingConfigurator)
 	{
 		if (State.IsInitialized)

--- a/src/app/ApplicationTemplate.Presentation/Framework/Version/VersionProviderExtensions.cs
+++ b/src/app/ApplicationTemplate.Presentation/Framework/Version/VersionProviderExtensions.cs
@@ -8,7 +8,7 @@ public static class VersionProviderExtensions
 	/// <summary>
 	/// Gets the full version string (Major.Minor.Build (Revision)).
 	/// </summary>
-	/// <param name="versionProvider"><see cref=""/>.</param>
+	/// <param name="versionProvider">The version provider.</param>
 	/// <returns>The full version string (Major.Minor.Build (Revision)).</returns>
 	public static string GetFullVersionString(this IVersionProvider versionProvider)
 	{

--- a/src/app/ApplicationTemplate.Presentation/Framework/ViewModels/ValueChangedOnBackgroundTaskDynamicPropertyFromDynamicProperty.cs
+++ b/src/app/ApplicationTemplate.Presentation/Framework/ViewModels/ValueChangedOnBackgroundTaskDynamicPropertyFromDynamicProperty.cs
@@ -118,7 +118,7 @@ public class ValueChangedOnBackgroundTaskDynamicPropertyFromDynamicProperty<T> :
 public class ValueChangedOnBackgroundTaskDynamicPropertyFromDynamicProperty<TSource, TResult> : ValueChangedOnBackgroundTaskDynamicPropertyFromDynamicProperty, IDynamicProperty<TResult>
 {
 	/// <summary>
-	/// Initializes a new instance of the <see cref="ValueChangedOnBackgroundTaskDynamicPropertyFromDynamicProperty{T}"/> class.
+	/// Initializes a new instance of the <see cref="ValueChangedOnBackgroundTaskDynamicPropertyFromDynamicProperty{TSource, TResult}"/> class.
 	/// </summary>
 	/// <param name="name">The name of the this property.</param>
 	/// <param name="source">Source.</param>

--- a/src/app/ApplicationTemplate.Presentation/ViewModels/Diagnostics/Configuration/ConfigurationDebuggerViewModel.cs
+++ b/src/app/ApplicationTemplate.Presentation/ViewModels/Diagnostics/Configuration/ConfigurationDebuggerViewModel.cs
@@ -194,6 +194,7 @@ public sealed partial class ConfigurationDebuggerViewModel : TabViewModel
 		return JsonSerializer.Serialize(result, _jsonOptions);
 	}
 
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1851:Possible multiple enumerations of 'IEnumerable' collection", Justification = "It's fine because it's an Any() before the real enumeration.")]
 	private static object GetConfigurationValue(IConfigurationSection section)
 	{
 		var children = section.GetChildren();
@@ -240,7 +241,7 @@ public sealed partial class ConfigurationDebuggerViewModel : TabViewModel
 
 	private static List<string> GetKeysFromOptionsTypes()
 	{
-		var optionsTypes = GetAssemblies().SelectMany(a => a.GetTypes().Where(t => t.Name.EndsWith("Options") && !t.IsAbstract && t.IsClass)).ToArray();
+		var optionsTypes = GetAssemblies().SelectMany(a => a.GetTypes().Where(t => t.Name.EndsWith("Options", StringComparison.Ordinal) && !t.IsAbstract && t.IsClass)).ToArray();
 		var keys = new List<string>();
 
 		foreach (var optionsType in optionsTypes)
@@ -313,7 +314,7 @@ public sealed partial class ConfigurationDebuggerViewModel : TabViewModel
 				for (int j = i + 1; j < keys.Count; j++)
 				{
 					var next = keys[j];
-					if (next.StartsWith(current))
+					if (next.StartsWith(current, StringComparison.Ordinal))
 					{
 						keys.RemoveAt(i);
 						--i;

--- a/src/app/ApplicationTemplate.Presentation/ViewModels/Diagnostics/DiagnosticsOverlayViewModel.cs
+++ b/src/app/ApplicationTemplate.Presentation/ViewModels/Diagnostics/DiagnosticsOverlayViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Reactive.Linq;
 using ByteSizeLib;
 using Chinook.DynamicMvvm;
@@ -161,12 +162,12 @@ public sealed partial class DiagnosticsOverlayViewModel : ViewModel
 		.Select(_ => DiagnosticsCountersService.Counters);
 
 	public string PrivateMemorySize => this.GetFromObservable(
-		source: _memoryProvider.ObservePrivateMemorySize().Select(x => ByteSize.FromBytes(x).ToString("0.#")),
+		source: _memoryProvider.ObservePrivateMemorySize().Select(x => ByteSize.FromBytes(x).ToString("0.#", CultureInfo.InvariantCulture)),
 		initialValue: string.Empty
 	);
 
 	public string ManagedMemorySize => this.GetFromObservable(
-		source: _memoryProvider.ObserveManagedMemorySize().Select(x => ByteSize.FromBytes(x).ToString("0.#")),
+		source: _memoryProvider.ObserveManagedMemorySize().Select(x => ByteSize.FromBytes(x).ToString("0.#", CultureInfo.InvariantCulture)),
 		initialValue: string.Empty
 	);
 }

--- a/src/app/ApplicationTemplate.Presentation/ViewModels/Diagnostics/SummaryDiagnosticsViewModel.cs
+++ b/src/app/ApplicationTemplate.Presentation/ViewModels/Diagnostics/SummaryDiagnosticsViewModel.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace ApplicationTemplate.Presentation;
 
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "Default behavior is acceptable for diagnostics.")]
 public partial class SummaryDiagnosticsViewModel : ViewModel
 {
 	private readonly DateTimeOffset _now = DateTimeOffset.Now;

--- a/src/app/ApplicationTemplate.Presentation/ViewModels/Posts/PostsPageViewModel.cs
+++ b/src/app/ApplicationTemplate.Presentation/ViewModels/Posts/PostsPageViewModel.cs
@@ -13,6 +13,7 @@ public partial class PostsPageViewModel : ViewModel
 {
 	private readonly Func<Task> _onGetPostsCalled;
 
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "It will be disposed by the DataLoader when passed via WithTrigger.")]
 	private readonly ManualDataLoaderTrigger _deletePostTrigger = new();
 
 	public PostsPageViewModel(Func<Task> onGetPostsCalled = null)

--- a/src/app/ApplicationTemplate.Presentation/ViewModels/Settings/LicensesPageViewModel.cs
+++ b/src/app/ApplicationTemplate.Presentation/ViewModels/Settings/LicensesPageViewModel.cs
@@ -43,7 +43,7 @@ public class LicensesPageViewModel : ViewModel
 
 		using (var streamReader = new StreamReader(resourceStream))
 		{
-			return await streamReader.ReadToEndAsync();
+			return await streamReader.ReadToEndAsync(ct);
 		}
 	}
 }

--- a/src/app/ApplicationTemplate.Shared.Views/Behaviors/FormattingTextBoxBehavior.Android.cs
+++ b/src/app/ApplicationTemplate.Shared.Views/Behaviors/FormattingTextBoxBehavior.Android.cs
@@ -91,7 +91,7 @@ public sealed partial class FormattingTextBoxBehavior
 		while (control != null);
 	}
 
-	private class FormattingTextInputFilter : Java.Lang.Object, Android.Text.IInputFilter
+	private sealed class FormattingTextInputFilter : Java.Lang.Object, Android.Text.IInputFilter
 	{
 		private string _stringFormat;
 		private TextBox _targetTextBox;

--- a/src/app/ApplicationTemplate.Shared.Views/Behaviors/FormattingTextBoxBehavior.iOS.cs
+++ b/src/app/ApplicationTemplate.Shared.Views/Behaviors/FormattingTextBoxBehavior.iOS.cs
@@ -74,6 +74,7 @@ public sealed partial class FormattingTextBoxBehavior
 		}
 	}
 
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "Delegate is fine in this case because it's not referring the delegate construct but rather the base class.")]
 	public class UITextFieldDelegatingDelegate : UITextFieldDelegate
 	{
 		private SinglelineTextBoxView _nativeView;

--- a/src/app/ApplicationTemplate.Shared.Views/Configuration/LoggingConfiguration.cs
+++ b/src/app/ApplicationTemplate.Shared.Views/Configuration/LoggingConfiguration.cs
@@ -58,6 +58,7 @@ public static class LoggingConfiguration
 #endif
 	}
 
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "False positive: These are message template. The brackets are expected.")]
 	private static LoggerConfiguration AddConsoleLogging(LoggerConfiguration configuration)
 	{
 		return configuration
@@ -78,6 +79,7 @@ public static class LoggingConfiguration
 //+:cnd:noEmit
 	}
 
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "False positive: These are message template. The brackets are expected.")]
 	private static LoggerConfiguration AddFileLogging(LoggerConfiguration configuration, string logFilePath)
 	{
 //-:cnd:noEmit

--- a/src/app/ApplicationTemplate.Shared.Views/Configuration/NavigationConfiguration.cs
+++ b/src/app/ApplicationTemplate.Shared.Views/Configuration/NavigationConfiguration.cs
@@ -26,7 +26,6 @@ public static class NavigationConfiguration
 	private static IReadOnlyDictionary<Type, Type> GetPageRegistrations() => new Dictionary<Type, Type>()
 	{
 		// TODO: Add your ViewModel and Page associations here.
-
 		{ typeof(WelcomePageViewModel), typeof(WelcomePage) },
 		{ typeof(PostsPageViewModel), typeof(PostsPage) },
 		{ typeof(EditPostPageViewModel), typeof(EditPostPage) },

--- a/src/app/ApplicationTemplate.Shared.Views/Controls/AppBarBackButton.cs
+++ b/src/app/ApplicationTemplate.Shared.Views/Controls/AppBarBackButton.cs
@@ -20,6 +20,7 @@ namespace ApplicationTemplate.Views.Controls;
 /// </remarks>
 public sealed partial class AppBarBackButton : AppBarButton
 {
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "It's disposed via OnUnloaded.")]
 	private IDisposable _backButtonVisibilitySubscription;
 
 	public AppBarBackButton()

--- a/src/app/ApplicationTemplate.Shared.Views/Framework/DiagnosticsService.cs
+++ b/src/app/ApplicationTemplate.Shared.Views/Framework/DiagnosticsService.cs
@@ -82,7 +82,7 @@ public class DiagnosticsService : IDiagnosticsService
 #if __IOS__
 //+:cnd:noEmit
 		/// This will be handled by <see cref="AppDomain.CurrentDomain.UnhandledException" />
-		UIKit.UIApplication.SharedApplication.InvokeOnMainThread(() => throw new Exception("This is a test of an exception in the MainThread. Please ignore."));
+		UIKit.UIApplication.SharedApplication.InvokeOnMainThread(() => throw new InvalidOperationException("This is a test of an exception in the MainThread. Please ignore."));
 //-:cnd:noEmit
 #elif __ANDROID__
 //+:cnd:noEmit

--- a/src/app/ApplicationTemplate.Shared.Views/Helpers/DispatcherQueueExtensions.cs
+++ b/src/app/ApplicationTemplate.Shared.Views/Helpers/DispatcherQueueExtensions.cs
@@ -63,6 +63,7 @@ internal static class DispatcherQueueExtensions
 	/// <param name="dispatcher">The target <see cref="DispatcherQueue"/> to invoke the code on.</param>
 	/// <param name="priority">The priority level for the function to invoke.</param>
 	/// <param name="asyncAction">The <see cref="DispatcherQueueHandler"/> to invoke.</param>
+	/// <typeparam name="T">The return type of the task.</typeparam>
 	/// <returns>A <see cref="Task"/> that completes when the invocation of <paramref name="asyncAction"/> is over.</returns>
 	/// <remarks>If the current thread has access to <paramref name="dispatcher"/>, <paramref name="asyncAction"/> will be invoked directly.</remarks>
 	internal static Task<T> RunTaskAsync<T>(this DispatcherQueue dispatcher, DispatcherQueuePriority priority, Func<Task<T>> asyncAction)

--- a/src/app/ApplicationTemplate.Shared.Views/Helpers/ObservableExtensions.cs
+++ b/src/app/ApplicationTemplate.Shared.Views/Helpers/ObservableExtensions.cs
@@ -42,27 +42,27 @@ internal enum SubscribeToElementOptions : byte
 internal enum UiEventSubscriptionsOptions
 {
 	/// <summary>
-	/// Default is ImmediateSubscribe.
-	/// </summary>
-	Default = ImmediateSubscribe,
-
-	/// <summary>
-	/// Subscribe and Unsubscribe will be enforced on Dispacther scheduler.
+	/// Subscribe and Unsubscribe will be enforced on Dispatcher scheduler.
 	/// </summary>
 	/// <remarks>Be sure to not miss an event between subscribe to observable and real event handler add.</remarks>
 	DispatcherOnly = 0,
 
 	/// <summary>
-	/// Add event handler immediatly on Subscribe.
+	/// Add event handler immediately on Subscribe.
 	/// </summary>
 	/// <remarks>This mean you must call subscribe on dispatcher.</remarks>
 	ImmediateSubscribe = 1,
 
 	/// <summary>
-	/// Remove event handler immediatly on Dispose / Complete.
+	/// Remove event handler immediately on Dispose / Complete.
 	/// </summary>
 	/// <remarks>This mean you must dispose subscription on dispatcher.</remarks>
 	ImmediateUnsubscribe = 2,
+
+	/// <summary>
+	/// Default is ImmediateSubscribe.
+	/// </summary>
+	Default = ImmediateSubscribe,
 }
 
 internal static class ObservableExtensions

--- a/stylecop.json
+++ b/stylecop.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {


### PR DESCRIPTION
GitHub Issue: #

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [ ] Bug fix
 - [x] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## Description

<!-- (Please describe the changes that this PR introduces.) -->
- Enable `TreatWarningsAsErrors` for the Access, Business, and Presentation projects.
- Update analyzers packages and severity of rules.


## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major**
  - The template structure was changed.
- [x] **Minor**
  - New functionalities were added.
- [ ] **Patch**
  - A bug in behavior was fixed.
  - Documentation was changed.

## PR Checklist 

### Always applicable
No matter your changes, these checks always apply.
- [x] Your conventional commits are aligned with the **Impact on version** section.
- [x] Updated [CHANGELOG.md](../CHANGELOG.md).
  - Use the latest Major.Minor.X header if you do a **Patch** change.
  - Create a new Major.Minor.X header if you do a **Minor** or **Major** change.
  - If you create a new header, it aligns with the **Impact on version** section and matches what is generated in the build pipeline.
- [x] Documentation files were updated according with the changes.
  - Update `README.md` and `TemplateConfig.md` if you made changes to **templating**.
  - Update `AzurePipelines.md` and `APP_README.md` if you made changes to **pipelines**.
  - Update `Diagnostics.md` if you made changes to **diagnostic tools**.
  - Update `Architecture.md` and its diagrams if you made **architecture decisions** or if you introduced new **recipes**.
  - ...and so forth: Make sure you update the documentation files associated to the recipes you changed. Review the topics by looking at the content of the `doc/` folder.
- [x] Images about the template are referenced from the [wiki](https://github.com/nventive/UnoApplicationTemplate/wiki/Images) and added as images in this git.
- [x] TODO comments are hints for next steps for users of the template and not planned work.

### Contextual
Based on your changes these checks may not apply.
- [ ] Automated tests for the changes have been added/updated.
- [ ] Tested on all relevant platforms

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->