### PR TITLE
fix: update canary ignored packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 Prefix your items with `(Template)` if the change is about the template and not the resulting application.
 
 ## 2.1.X
+- Ignore packages `Uno.CommunityToolkit.WinUI` and `Uno.WinUI.Lottie` in `canary-merge.yml` to prevent canary from failing.
 - Install `GooseAnalyzers` to enable the `SA1600` rule with its scope limited to interfaces and improve xml documentation.
 - Replace local `DispatcherQueue` extension methods with the ones from the WinUI and Uno.WinUI Community Toolkit.
 - Add `Microsoft.VisualStudio.Threading.Analyzers` to check for async void usages and fix async void usages.

--- a/build/canary-merge.yml
+++ b/build/canary-merge.yml
@@ -1,4 +1,4 @@
-schedules:
+﻿schedules:
 - cron: "00 05 * * Mon-Fri" # Format is "Minutes Hours DayOfMonth Month DayOfWeek" in UTC (that's why 05 is 1h EST)
   displayName: 'Nightly weekdays build - 1:00 EST'
   always: true # Start a new run even if the code didn't change (because packages might have changed).
@@ -46,7 +46,7 @@ steps:
     nugetVersion: 'dev,beta,stable'
     allowDowngrade: true
     packageAuthor: 'nventive'
-    ignorePackages: 'GeneratedSerializers.Json;Nventive.View.Uno;BiometryService'
+    ignorePackages: 'GeneratedSerializers.Json;Nventive.View.Uno;BiometryService;Uno.CommunityToolkit.WinUI;Uno.WinUI.Lottie'
     useVersionOverrides: true
     versionOverridesFile: 'https://raw.githubusercontent.com/nventive/Canary/master/version-overrides.json'
 


### PR DESCRIPTION
GitHub Issue: #

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [ ] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [x] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## Description

<!-- (Please describe the changes that this PR introduces.) -->
Ignore Uno.CommunityToolkit.WinUI and Uno.WinUI.Lottie packages in canary merge to prevent canary from failing.

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major**
  - The template structure was changed.
- [ ] **Minor**
  - New functionalities were added.
- [x] **Patch**
  - A bug in behavior was fixed.
  - Documentation was changed.

## PR Checklist 

### Always applicable
No matter your changes, these checks always apply.
- [x] Your conventional commits are aligned with the **Impact on version** section.
- [x] Updated [CHANGELOG.md](../CHANGELOG.md).
  - Use the latest Major.Minor.X header if you do a **Patch** change.
  - Create a new Major.Minor.X header if you do a **Minor** or **Major** change.
  - If you create a new header, it aligns with the **Impact on version** section and matches what is generated in the build pipeline.
- [x] Documentation files were updated according with the changes.
  - Update `README.md` and `TemplateConfig.md` if you made changes to **templating**.
  - Update `AzurePipelines.md` and `APP_README.md` if you made changes to **pipelines**.
  - Update `Diagnostics.md` if you made changes to **diagnostic tools**.
  - Update `Architecture.md` and its diagrams if you made **architecture decisions** or if you introduced new **recipes**.
  - ...and so forth: Make sure you update the documentation files associated to the recipes you changed. Review the topics by looking at the content of the `doc/` folder.
- [x] Images about the template are referenced from the [wiki](https://github.com/nventive/UnoApplicationTemplate/wiki/Images) and added as images in this git.
- [x] TODO comments are hints for next steps for users of the template and not planned work.

### Contextual
Based on your changes these checks may not apply.
- [ ] Automated tests for the changes have been added/updated.
- [x] Tested on all relevant platforms

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
[Bug 293724](https://dev.azure.com/nventive/Practice%20committees/_workitems/edit/293724): Fix the build stage of the UnoApplicationTemplate canary pipeline