### PR TITLE
fix: Remove usage of deprecated Material V1 resources in diagnostics styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Prefix your items with `(Template)` if the change is about the template and not 
 - Updated to .NET 8.
 - Added MAUI essentials on Windows.
 - Fixed MAUI essentials warning.
+- Fixed WinUI crashes in diagnostics screens.
 
 ## 3.0.X
 - Updated to Uno 5.

--- a/src/app/ApplicationTemplate.Shared.Views/Content/Diagnostics/ConfigurationDebuggerView.xaml
+++ b/src/app/ApplicationTemplate.Shared.Views/Content/Diagnostics/ConfigurationDebuggerView.xaml
@@ -438,7 +438,7 @@
 												  MinWidth="{ThemeResource ComboBoxPopupThemeMinWidth}"
 												  AutomationProperties.AccessibilityView="Raw"
 												  BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
-												  CornerRadius="{StaticResource MaterialComboBoxCornerRadius}"
+												  CornerRadius="4"
 												  HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
 												  HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
 												  IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"

--- a/src/app/ApplicationTemplate.Shared.Views/Content/Diagnostics/HttpDebuggerView.xaml
+++ b/src/app/ApplicationTemplate.Shared.Views/Content/Diagnostics/HttpDebuggerView.xaml
@@ -24,6 +24,8 @@
 						 Color="#FFFF8888" />
 		<SolidColorBrush x:Key="SelectionBackgroundBrush"
 						 Color="#33FFFFFF" />
+		<SolidColorBrush x:Key="FocusedBorderBrush"
+						 Color="#55FFFFFF" />
 
 		<Style x:Key="HttpDebuggerTextBlockStyle"
 			   TargetType="TextBlock">
@@ -71,7 +73,7 @@
 									<VisualState x:Name="Focused">
 										<VisualState.Setters>
 											<Setter Target="Root.BorderBrush"
-													Value="{StaticResource TextBoxFilledFocusIndicatorColorBrush}" />
+													Value="{StaticResource FocusedBorderBrush}" />
 										</VisualState.Setters>
 									</VisualState>
 								</VisualStateGroup>


### PR DESCRIPTION
GitHub Issue: #

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [x] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## Description

<!-- (Please describe the changes that this PR introduces.) -->
- Remove usage of deprecated Material V1 resources in diagnostics which caused crashes on WinUI.

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major**
  - The template structure was changed.
- [ ] **Minor**
  - New functionalities were added.
- [x] **Patch**
  - A bug in behavior was fixed.
  - Documentation was changed.

## PR Checklist 

### Always applicable
No matter your changes, these checks always apply.
- [x] Your conventional commits are aligned with the **Impact on version** section.
- [x] Updated [CHANGELOG.md](../CHANGELOG.md).
  - Use the latest Major.Minor.X header if you do a **Patch** change.
  - Create a new Major.Minor.X header if you do a **Minor** or **Major** change.
  - If you create a new header, it aligns with the **Impact on version** section and matches what is generated in the build pipeline.
- [x] Documentation files were updated according with the changes.
  - Update `README.md` and `TemplateConfig.md` if you made changes to **templating**.
  - Update `AzurePipelines.md` and `APP_README.md` if you made changes to **pipelines**.
  - Update `Diagnostics.md` if you made changes to **diagnostic tools**.
  - Update `Architecture.md` and its diagrams if you made **architecture decisions** or if you introduced new **recipes**.
  - ...and so forth: Make sure you update the documentation files associated to the recipes you changed. Review the topics by looking at the content of the `doc/` folder.
- [x] Images about the template are referenced from the [wiki](https://github.com/nventive/UnoApplicationTemplate/wiki/Images) and added as images in this git.
- [x] TODO comments are hints for next steps for users of the template and not planned work.

### Contextual
Based on your changes these checks may not apply.
- [ ] Automated tests for the changes have been added/updated.
- [ ] Tested on all relevant platforms

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->