### PR TITLE
fix: add tag-prefix on git config to avoid automatically change versi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Prefix your items with `(Template)` if the change is about the template and not 
 ## 3.2.X
 - Added support for mouse back button navigation.
 - Set `fetchDepth` to 0 on canary merge CI to avoid `refusing to merge unrelated histories` errors.
+- Set 'tag-prefix' on `gitversion-config.yml` to avoid version & build number automatically changing depending on tags & release branches. 
 
 ## 3.1.X
 - Updated to .NET 8.

--- a/build/gitversion-config.yml
+++ b/build/gitversion-config.yml
@@ -2,6 +2,7 @@ assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDeployment
 next-version: 1.0.0
 continuous-delivery-fallback-tag: ""
+tag-prefix: '(?!x)x' # Use a regex pattern impossible to match so it never affects build version & number.
 branches:
   main:
     regex: ^master$|^main$


### PR DESCRIPTION
…on depending on branch/tag

GitHub Issue: #

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [x] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## Description

On projects that have been started from this template, I always had issues where the build number will reset to 0 when I create a new tag named `v{version}` or a new branch named `release/v{version}`. To fix it, I'm setting `tag-prefix` to a regex that is impossible to match.

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major**
  - The template structure was changed.
- [ ] **Minor**
  - New functionalities were added.
- [x] **Patch**
  - A bug in behavior was fixed.
  - Documentation was changed.

## PR Checklist 

### Always applicable
No matter your changes, these checks always apply.
- [x] Your conventional commits are aligned with the **Impact on version** section.
- [x] Updated [CHANGELOG.md](../CHANGELOG.md).
  - Use the latest Major.Minor.X header if you do a **Patch** change.
  - Create a new Major.Minor.X header if you do a **Minor** or **Major** change.
  - If you create a new header, it aligns with the **Impact on version** section and matches what is generated in the build pipeline.
- [x] Documentation files were updated according with the changes.
  - Update `README.md` and `TemplateConfig.md` if you made changes to **templating**.
  - Update `AzurePipelines.md` and `APP_README.md` if you made changes to **pipelines**.
  - Update `Diagnostics.md` if you made changes to **diagnostic tools**.
  - Update `Architecture.md` and its diagrams if you made **architecture decisions** or if you introduced new **recipes**.
  - ...and so forth: Make sure you update the documentation files associated to the recipes you changed. Review the topics by looking at the content of the `doc/` folder.
- [x] Images about the template are referenced from the [wiki](https://github.com/nventive/UnoApplicationTemplate/wiki/Images) and added as images in this git.
- [x] TODO comments are hints for next steps for users of the template and not planned work.

### Contextual
Based on your changes these checks may not apply.
- [ ] Automated tests for the changes have been added/updated.
- [ ] Tested on all relevant platforms

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->