### PR TITLE
fix: Workaround for Posts page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Prefix your items with `(Template)` if the change is about the template and not 
 - Added a kill switch feature to the app.
 - Bump Uno.WinUI, Uno.WinUI.DevServer, Uno.WinUI.Lottie and Uno.UI.Adapter.Microsoft.Extensions.Logging to 5.0.159 to fix backNavigation/CloseModal crash.
 - Fixed an issue with logging configuration not creating the directory before writing the log file in the case logging was disabled by default.
+- Fixed Post commands binding issue on Android.
 
 ## 3.3.X
 - Added a forced update feature to the app.

--- a/src/app/ApplicationTemplate.Presentation/ViewModels/Posts/PostItemViewModel.cs
+++ b/src/app/ApplicationTemplate.Presentation/ViewModels/Posts/PostItemViewModel.cs
@@ -1,0 +1,41 @@
+﻿using ApplicationTemplate.Business;
+using Chinook.DynamicMvvm;
+using Chinook.StackNavigation;
+
+namespace ApplicationTemplate.Presentation;
+
+/// <summary>
+/// Post item view model.
+/// </summary>
+public sealed class PostItemViewModel : ViewModel
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="PostItemViewModel"/> class.
+	/// </summary>
+	/// <param name="post">The post.</param>
+	public PostItemViewModel(Post post)
+	{
+		Post = post;
+	}
+
+	/// <summary>
+	/// The post.
+	/// </summary>
+	public Post Post { get; }
+
+	/// <summary>
+	/// Deletes the post.
+	/// </summary>
+	public IDynamicCommand DeletePost => this.GetCommandFromTask(async (ct) =>
+	{
+		await this.GetService<IPostService>().Delete(ct, Post.Id);
+	});
+
+	/// <summary>
+	/// Navigates to the edit post page.
+	/// </summary>
+	public IDynamicCommand EditPost => this.GetCommandFromTask(async (ct) =>
+	{
+		await this.GetService<IStackNavigator>().Navigate(ct, () => new EditPostPageViewModel(Post));
+	});
+}

--- a/src/app/ApplicationTemplate.Shared.Views/Content/Posts/PostsPage.xaml
+++ b/src/app/ApplicationTemplate.Shared.Views/Content/Posts/PostsPage.xaml
@@ -4,8 +4,7 @@
 	  xmlns:u="using:Nventive.View.Controls"
 	  xmlns:dl="using:Chinook.DataLoader">
 
-	<Grid x:Name="PostPage"
-		  Background="{ThemeResource BackgroundBrush}">
+	<Grid Background="{ThemeResource BackgroundBrush}">
 
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto" />
@@ -17,15 +16,13 @@
 					x:Uid="Posts_CommandBar" />
 
 		<Grid Grid.Row="1">
-
 			<!-- DataLoader View -->
 			<dl:DataLoaderView x:Name="PostsDataLoaderView"
 							   Source="{Binding Posts}">
-				<DataTemplate>
 
+				<DataTemplate>
 					<!-- Swipe to Refresh -->
-					<u:SwipeRefresh x:Name="RefreshContent"
-									RefreshCommand="{Binding ElementName=PostsDataLoaderView, Path=RefreshCommand}"
+					<u:SwipeRefresh RefreshCommand="{Binding ElementName=PostsDataLoaderView, Path=RefreshCommand}"
 									IsRefreshing="{Binding ElementName=PostsDataLoaderView, Path=RefreshCommand.IsExecuting}"
 									IndicatorColor="{ThemeResource PrimaryBrush}">
 
@@ -33,17 +30,16 @@
 						<ListView ItemsSource="{Binding Data}">
 							<ListView.ItemTemplate>
 								<DataTemplate>
-
 									<StackPanel Background="{ThemeResource SurfaceBrush}"
 												Margin="0,16,0,0"
 												Padding="16">
 
 										<!-- Title -->
-										<TextBlock Text="{Binding Title}"
+										<TextBlock Text="{Binding Post.Title}"
 												   Style="{StaticResource TitleMedium}" />
 
 										<!-- Body -->
-										<TextBlock Text="{Binding Body}"
+										<TextBlock Text="{Binding Post.Body}"
 												   Foreground="{ThemeResource OnSurfaceBrush}"
 												   Style="{StaticResource BodyMedium}"
 												   Opacity="{StaticResource MediumOpacity}"
@@ -55,14 +51,12 @@
 
 											<!-- Delete Button -->
 											<Button Content="Delete"
-													Command="{Binding ElementName=PostPage, Path=DataContext.DeletePost}"
-													CommandParameter="{Binding}"
+													Command="{Binding DeletePost}"
 													Style="{StaticResource OutlinedButtonStyle}" />
 
 											<!-- Edit Button -->
 											<Button Content="Edit"
-													Command="{Binding ElementName=PostPage, Path=DataContext.NavigateToPost}"
-													CommandParameter="{Binding}"
+													Command="{Binding EditPost}"
 													Margin="4,0,0,0" />
 										</StackPanel>
 									</StackPanel>
@@ -74,8 +68,7 @@
 			</dl:DataLoaderView>
 
 			<!-- Create New Post Button -->
-			<Button Command="{Binding NavigateToNewPost}"
-					CommandParameter="{Binding}"
+			<Button Command="{Binding CreatePost}"
 					Style="{StaticResource IconButtonStyle}"
 					Background="Transparent"
 					HorizontalAlignment="Right"

--- a/src/app/ApplicationTemplate.Tests.Functional/Posts/EditPostPageViewModelShould.cs
+++ b/src/app/ApplicationTemplate.Tests.Functional/Posts/EditPostPageViewModelShould.cs
@@ -1,14 +1,7 @@
-﻿using System;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using ApplicationTemplate.Business;
-using ApplicationTemplate.Presentation;
-using Chinook.DynamicMvvm;
-using FluentAssertions;
-using FluentAssertions.Execution;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace ApplicationTemplate.Tests;
@@ -27,10 +20,12 @@ public sealed class EditPostPageViewModelShould : FunctionalTestBase
 		await Menu.ShowPostsSection.Execute();
 
 		var postsVM = GetAndAssertActiveViewModel<PostsPageViewModel>();
-		var posts = await postsVM.Posts.Load(CancellationToken.None) as ImmutableList<Post>;
+		var postItemViewModels = await postsVM.Posts.Load(CancellationToken.None) as ImmutableList<PostItemViewModel>;
 
-		var post = posts.First();
-		await postsVM.NavigateToPost.Execute(post);
+		var postItemViewModel = postItemViewModels.First();
+		var post = postItemViewModel.Post;
+
+		await postItemViewModel.EditPost.Execute();
 		var sut = GetAndAssertActiveViewModel<EditPostPageViewModel>();
 
 		// Assert


### PR DESCRIPTION
GitHub Issue: #

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [x] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## Description

<!-- (Please describe the changes that this PR introduces.) -->

Now we can use the edit and delete buttons on Android in the posts page.

See https://github.com/unoplatform/uno/issues/13996 for more details.

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major**
  - The template structure was changed.
- [ ] **Minor**
  - New functionalities were added.
- [x] **Patch**
  - A bug in behavior was fixed.
  - Documentation was changed.

## PR Checklist 

### Always applicable
No matter your changes, these checks always apply.
- [x] Your conventional commits are aligned with the **Impact on version** section.
- [x] Updated [CHANGELOG.md](../CHANGELOG.md).
  - Use the latest Major.Minor.X header if you do a **Patch** change.
  - Create a new Major.Minor.X header if you do a **Minor** or **Major** change.
  - If you create a new header, it aligns with the **Impact on version** section and matches what is generated in the build pipeline.
- [x] Documentation files were updated according with the changes.
  - Update `README.md` and `TemplateConfig.md` if you made changes to **templating**.
  - Update `AzurePipelines.md` and `APP_README.md` if you made changes to **pipelines**.
  - Update `Diagnostics.md` if you made changes to **diagnostic tools**.
  - Update `Architecture.md` and its diagrams if you made **architecture decisions** or if you introduced new **recipes**.
  - ...and so forth: Make sure you update the documentation files associated to the recipes you changed. Review the topics by looking at the content of the `doc/` folder.
- [x] Images about the template are referenced from the [wiki](https://github.com/nventive/UnoApplicationTemplate/wiki/Images) and added as images in this git.
- [x] TODO comments are hints for next steps for users of the template and not planned work.

### Contextual
Based on your changes these checks may not apply.
- [x] Automated tests for the changes have been added/updated.
- [x] Tested on all relevant platforms

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->