### PR TITLE
ci: ensure nuget release is only executed from the main branch

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -23,6 +23,10 @@ trigger:
       - main
 
 variables:
+#-if false
+- name: IsReleaseBranch
+  value: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
+#-endif
 - template: build/variables.yml
 
 stages:
@@ -49,7 +53,7 @@ stages:
       iosVariableGroup: 'ApplicationTemplate.Distribution.Internal.iOS'
 
 - stage: Publish_Template_Package
-  condition: and(succeeded(), eq(variables['IsLightBuild'], 'false'))
+  condition: and(succeeded(), eq(variables['IsLightBuild'], 'false'), eq(variables['IsReleaseBranch'], 'true'))
   dependsOn:
    - Build_Staging_GeneratedApp
    - Build_Staging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Prefix your items with `(Template)` if the change is about the template and not 
 
 ## 3.5.X
 - Bump Uno packages to 5.2.121 to fix a crash on iOS.
+- Ensure NV.Template.Mobile nuget is only deployed from the main branch.
 
 ## 3.4.X
 - Added a kill switch feature to the app.


### PR DESCRIPTION
GitHub Issue: #

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [ ] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [x] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## Description

I've made sure that the CI task to release the nv template mobile nuget can only be executed from the main branch


## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major**
  - The template structure was changed.
- [ ] **Minor**
  - New functionalities were added.
- [ ] **Patch**
  - A bug in behavior was fixed.
  - Documentation was changed.

## PR Checklist 

### Always applicable
No matter your changes, these checks always apply.
- [x] Your conventional commits are aligned with the **Impact on version** section.
- [x] Updated [CHANGELOG.md](../CHANGELOG.md).
  - Use the latest Major.Minor.X header if you do a **Patch** change.
  - Create a new Major.Minor.X header if you do a **Minor** or **Major** change.
  - If you create a new header, it aligns with the **Impact on version** section and matches what is generated in the build pipeline.
- [x] Documentation files were updated according with the changes.
  - Update `README.md` and `TemplateConfig.md` if you made changes to **templating**.
  - Update `AzurePipelines.md` and `APP_README.md` if you made changes to **pipelines**.
  - Update `Diagnostics.md` if you made changes to **diagnostic tools**.
  - Update `Architecture.md` and its diagrams if you made **architecture decisions** or if you introduced new **recipes**.
  - ...and so forth: Make sure you update the documentation files associated to the recipes you changed. Review the topics by looking at the content of the `doc/` folder.
- [x] Images about the template are referenced from the [wiki](https://github.com/nventive/UnoApplicationTemplate/wiki/Images) and added as images in this git.
- [x] TODO comments are hints for next steps for users of the template and not planned work.

### Contextual
Based on your changes these checks may not apply.
- [ ] Automated tests for the changes have been added/updated.
- [ ] Tested on all relevant platforms

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->