### PR TITLE
fix: Safe area at the top is broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Prefix your items with `(Template)` if the change is about the template and not 
 - Fixed iOS crash by updating package and configuring the interpreter.
 - Added support for arm64 and x86 cpus in the mobile project.
 - Update Uno packages from 5.2.121 to 5.5.95.
+- Adding workaround for uno safe area issue https://github.com/unoplatform/uno/issues/6218
 
 ## 3.7.X
 - Replacing Appcenter with Firebase app distribution for Android.

--- a/src/app/ApplicationTemplate.Mobile/ApplicationTemplate.Mobile.csproj
+++ b/src/app/ApplicationTemplate.Mobile/ApplicationTemplate.Mobile.csproj
@@ -32,10 +32,10 @@
 		<PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Interactivity.WinUI" Version="2.4.2" />
 		<PackageReference Include="Uno.Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.4.2" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="6.3.7" />
-		<PackageReference Include="Uno.WinUI" Version="5.5.95" />
-		<PackageReference Include="Uno.WinUI.DevServer" Version="5.5.95" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="5.5.95" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.5.95" />
+		<PackageReference Include="Uno.WinUI" Version="5.6.30" />
+		<PackageReference Include="Uno.WinUI.DevServer" Version="5.6.30" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="5.6.30" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.6.30" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
 		<PackageReference Include="Serilog.Sinks.Xamarin" Version="1.0.0" />
 		<PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />

--- a/src/app/ApplicationTemplate.Shared.Views/ApplicationTemplate.Shared.Views.projitems
+++ b/src/app/ApplicationTemplate.Shared.Views/ApplicationTemplate.Shared.Views.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)behaviors\CommandBarSafeAreaBehavior.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Behaviors\FormattingTextBoxBehavior.Android.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Behaviors\FormattingTextBoxBehavior.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Behaviors\FormattingTextBoxBehavior.iOS.cs" />

--- a/src/app/ApplicationTemplate.Shared.Views/Behaviors/CommandBarSafeAreaBehavior.cs
+++ b/src/app/ApplicationTemplate.Shared.Views/Behaviors/CommandBarSafeAreaBehavior.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace ApplicationTemplate.Views.Behaviors;
+
+public class CommandBarSafeAreaBehavior
+{
+	public static bool GetApplySafeAreaWorkaround(DependencyObject obj) => (bool)obj.GetValue(ApplySafeAreaWorkaroundProperty);
+
+	public static void SetApplySafeAreaWorkaround(DependencyObject obj, bool value) => obj.SetValue(ApplySafeAreaWorkaroundProperty, value);
+
+	public static readonly DependencyProperty ApplySafeAreaWorkaroundProperty =
+		DependencyProperty.RegisterAttached(
+			"ApplySafeAreaWorkaround",
+			typeof(bool),
+			typeof(CommandBarSafeAreaBehavior),
+			new PropertyMetadata(false, OnPropertyChanged));
+
+	private static void OnPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+	{
+		if (d is CommandBar commandBar && (bool)e.NewValue)
+		{
+#if ANDROID
+			commandBar.Loaded += (s, args) =>
+			{
+				// We only need to apply the workaround on Android other platforms work well without it.
+				// See this issue:https://github.com/unoplatform/uno/issues/6218
+				var statusBar = Windows.UI.ViewManagement.StatusBar.GetForCurrentView().OccludedRect.Height;
+				commandBar.Margin = new Thickness(0, statusBar, 0, 0);
+			};
+#endif
+		}
+	}
+}

--- a/src/app/ApplicationTemplate.Shared.Views/Styles/Controls/CommandBar.xaml
+++ b/src/app/ApplicationTemplate.Shared.Views/Styles/Controls/CommandBar.xaml
@@ -2,6 +2,7 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:toolkit="using:Uno.UI.Toolkit"
+					xmlns:behaviors="using:ApplicationTemplate.Views.Behaviors"
 					xmlns:c="using:ApplicationTemplate.Views.Controls">
 
 	<!-- 
@@ -130,6 +131,9 @@
 
 		<Setter Property="toolkit:VisibleBoundsPadding.PaddingMask"
 				Value="Top" />
+
+		<Setter Property="behaviors:CommandBarSafeAreaBehavior.ApplySafeAreaWorkaround"
+				Value="True" />
 	</Style>
 
 	<Style x:Key="TransparentCommandBarStyle"


### PR DESCRIPTION
GitHub Issue: #

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [x] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## Description
Uno update broke the safearea again so applying workaround. 
<!-- (Please describe the changes that this PR introduces.) -->
![image](https://github.com/user-attachments/assets/31b5be2a-4d22-4633-976d-34041bcb3081)

![image](https://github.com/user-attachments/assets/4f49903d-36d7-4826-92b7-28c6e1577407)


## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major**
  - The template structure was changed.
- [ ] **Minor**
  - New functionalities were added.
- [x] **Patch**
  - A bug in behavior was fixed.
  - Documentation was changed.

## PR Checklist 

### Always applicable
No matter your changes, these checks always apply.
- [x] Your conventional commits are aligned with the **Impact on version** section.
- [x] Updated [CHANGELOG.md](../blob/main/CHANGELOG.md).
  - Use the latest Major.Minor.X header if you do a **Patch** change.
  - Create a new Major.Minor.X header if you do a **Minor** or **Major** change.
  - If you create a new header, it aligns with the **Impact on version** section and matches what is generated in the build pipeline.
- [ ] Documentation files were updated according with the changes.
  - Update `README.md` and `TemplateConfig.md` if you made changes to **templating**.
  - Update `AzurePipelines.md` and `APP_README.md` if you made changes to **pipelines**.
  - Update `Diagnostics.md` if you made changes to **diagnostic tools**.
  - Update `Architecture.md` and its diagrams if you made **architecture decisions** or if you introduced new **recipes**.
  - ...and so forth: Make sure you update the documentation files associated to the recipes you changed. Review the topics by looking at the content of the `doc/` folder.
- [ ] Images about the template are referenced from the [wiki](https://github.com/nventive/UnoApplicationTemplate/wiki/Images) and added as images in this git.
- [ ] TODO comments are hints for next steps for users of the template and not planned work.

### Contextual
Based on your changes these checks may not apply.
- [ ] Automated tests for the changes have been added/updated.
- [x] Tested on all relevant platforms

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->