### PR TITLE
fix: Missing material resource key MaterialCommandBarHeight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Prefix your items with `(Template)` if the change is about the template and not 
 - Added support for arm64 and x86 cpus in the mobile project.
 - Update Uno packages from 5.2.121 to 5.5.95.
 - Adding workaround for uno safe area issue https://github.com/unoplatform/uno/issues/6218
+- Removing MaterialCommandbarHeight property.
 
 ## 3.7.X
 - Replacing Appcenter with Firebase app distribution for Android.

--- a/src/app/ApplicationTemplate.Shared.Views/Styles/Controls/CommandBar.xaml
+++ b/src/app/ApplicationTemplate.Shared.Views/Styles/Controls/CommandBar.xaml
@@ -31,8 +31,6 @@
 				<!-- Note: NavigationCommand is an AppBarButton, not an ICommand. -->
 				<ContentControl Content="{Binding (toolkit:CommandBarExtensions.NavigationCommand), RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource NullableAppBarButtonToAppBarButton}}"
 								Foreground="{TemplateBinding Foreground}"
-								MaxHeight="{StaticResource MaterialCommandBarHeight}"
-								MaxWidth="{StaticResource MaterialCommandBarHeight}"
 								IsTabStop="False" />
 
 				<!--
@@ -87,9 +85,6 @@
 				</DataTemplate>
 			</Setter.Value>
 		</Setter>
-
-		<Setter Property="Height"
-				Value="{StaticResource MaterialCommandBarHeight}" />
 
 		<Setter Property="HorizontalAlignment"
 				Value="Stretch" />


### PR DESCRIPTION
GitHub Issue: #

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [x] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## Description

The commandbar height property was not needed and causing problems on windows. Plus on other projects we either don't set it or we set it to 48 manually which is the value in uno.material. I found that even without the setter the commandbar has the same height by default.

<!-- (Please describe the changes that this PR introduces.) -->


## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major**
  - The template structure was changed.
- [ ] **Minor**
  - New functionalities were added.
- [x] **Patch**
  - A bug in behavior was fixed.
  - Documentation was changed.

## PR Checklist 

### Always applicable
No matter your changes, these checks always apply.
- [x] Your conventional commits are aligned with the **Impact on version** section.
- [x] Updated [CHANGELOG.md](../blob/main/CHANGELOG.md).
  - Use the latest Major.Minor.X header if you do a **Patch** change.
  - Create a new Major.Minor.X header if you do a **Minor** or **Major** change.
  - If you create a new header, it aligns with the **Impact on version** section and matches what is generated in the build pipeline.
- [ ] Documentation files were updated according with the changes.
  - Update `README.md` and `TemplateConfig.md` if you made changes to **templating**.
  - Update `AzurePipelines.md` and `APP_README.md` if you made changes to **pipelines**.
  - Update `Diagnostics.md` if you made changes to **diagnostic tools**.
  - Update `Architecture.md` and its diagrams if you made **architecture decisions** or if you introduced new **recipes**.
  - ...and so forth: Make sure you update the documentation files associated to the recipes you changed. Review the topics by looking at the content of the `doc/` folder.
- [ ] Images about the template are referenced from the [wiki](https://github.com/nventive/UnoApplicationTemplate/wiki/Images) and added as images in this git.
- [ ] TODO comments are hints for next steps for users of the template and not planned work.

### Contextual
Based on your changes these checks may not apply.
- [ ] Automated tests for the changes have been added/updated.
- [x] Tested on all relevant platforms

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->