### PR TITLE
ci: Fix Commits Validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ Prefix your items with `(Template)` if the change is about the template and not 
 - Updated Pipeline Code Coverage Task from V1 to V2.
 - Fixed iOS crash by updating package and configuring the interpreter.
 - Added support for arm64 and x86 cpus in the mobile project.
-- Update Uno packages from 5.2.121 to 5.5.95.
+- Updated Uno packages from 5.2.121 to 5.6.30.
 - Adding workaround for uno safe area issue https://github.com/unoplatform/uno/issues/6218
 - Removing MaterialCommandbarHeight property.
+- Updated commit validation for the CI/CD.
 
 ## 3.7.X
 - Replacing Appcenter with Firebase app distribution for Android.

--- a/build/templates/validate-commits.yaml
+++ b/build/templates/validate-commits.yaml
@@ -1,4 +1,4 @@
-# This template is used to validate that the commit messages follow the Conventional Commits specification (https://www.conventionalcommits.org/en/v1.0.0/).
+﻿# This template is used to validate that the commit messages follow the Conventional Commits specification (https://www.conventionalcommits.org/en/v1.0.0/).
 # Consider placing this at the beginning of the build pipeline to ensure that the commits are valid before proceeding with longer build steps.
 steps:
   - task: PowerShell@2
@@ -18,8 +18,9 @@ steps:
         Write-Host "Retrieving commits..."
         git fetch origin
         Write-Host "Commit Range: origin/$(System.PullRequest.TargetBranch)..origin/$(System.PullRequest.SourceBranch)"
-        $commits = git log origin/$(System.PullRequest.TargetBranch)..origin/$(System.PullRequest.SourceBranch) --pretty=format:"%H %B"
-        $commitCount = ($commits | Measure-Object).Count
+        $commits = git log origin/$(System.PullRequest.TargetBranch)..origin/$(System.PullRequest.SourceBranch) --pretty=format:"%s"
+        $commitArray = $commits -split "`n"
+        $commitCount = $commitArray.Count
         Write-Host "Commits found: $commitCount"
 
         # Regex pattern for Conventional Commits
@@ -28,8 +29,8 @@ steps:
 
         # Validate each commit message
         $invalidCommits = @()
-        foreach ($commit in $commits -split "`n") {
-          $commitMessage = $commit.Substring($commit.IndexOf(" ") + 1)
+        foreach ($commit in $commitArray) {
+          $commitMessage = $commit.Trim()
           Write-Host "Validating commit: $commitMessage"
 
           if ($commitMessage -notmatch $pattern) {


### PR DESCRIPTION
GitHub Issue: #

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [ ] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [x] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## Description

<!-- (Please describe the changes that this PR introduces.) -->

I fixed the commits validator for [this](https://github.com/nventive/UnoApplicationTemplate/pull/430) pull request.

[Source](https://github.com/nventive/FlutterApplicationTemplate/pull/54).

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major**
  - The template structure was changed.
- [ ] **Minor**
  - New functionalities were added.
- [x] **Patch**
  - A bug in behavior was fixed.
  - Documentation was changed.

## PR Checklist 

### Always applicable
No matter your changes, these checks always apply.
- [x] Your conventional commits are aligned with the **Impact on version** section.
- [x] Updated [CHANGELOG.md](../blob/main/CHANGELOG.md).
  - Use the latest Major.Minor.X header if you do a **Patch** change.
  - Create a new Major.Minor.X header if you do a **Minor** or **Major** change.
  - If you create a new header, it aligns with the **Impact on version** section and matches what is generated in the build pipeline.
- [x] Documentation files were updated according with the changes.
  - Update `README.md` and `TemplateConfig.md` if you made changes to **templating**.
  - Update `AzurePipelines.md` and `APP_README.md` if you made changes to **pipelines**.
  - Update `Diagnostics.md` if you made changes to **diagnostic tools**.
  - Update `Architecture.md` and its diagrams if you made **architecture decisions** or if you introduced new **recipes**.
  - ...and so forth: Make sure you update the documentation files associated to the recipes you changed. Review the topics by looking at the content of the `doc/` folder.
- [x] Images about the template are referenced from the [wiki](https://github.com/nventive/UnoApplicationTemplate/wiki/Images) and added as images in this git.
- [x] TODO comments are hints for next steps for users of the template and not planned work.

### Contextual
Based on your changes these checks may not apply.
- [ ] Automated tests for the changes have been added/updated.
- [ ] Tested on all relevant platforms

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->