### PR TITLE
fix: Properly use the JsonContext for Refit serialization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Prefix your items with `(Template)` if the change is about the template and not 
 - Adding workaround for uno safe area issue https://github.com/unoplatform/uno/issues/6218
 - Removing MaterialCommandbarHeight property.
 - Updated commit validation for the CI/CD.
+- Added missing association between JsonContext and Refit.
 
 ## 3.7.X
 - Replacing Appcenter with Firebase app distribution for Android.

--- a/src/app/ApplicationTemplate.Access/Configuration/SerializationConfiguration.cs
+++ b/src/app/ApplicationTemplate.Access/Configuration/SerializationConfiguration.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Serialization;
 using ApplicationTemplate.DataAccess;
 using Microsoft.Extensions.DependencyInjection;
 using Nventive.Persistence;
+using Refit;
 
 namespace ApplicationTemplate;
 
@@ -69,6 +70,9 @@ public static class SerializationConfiguration
 	{
 		services
 			.AddSingleton(DefaultJsonSerializerOptions)
+			// Add the adapter for Refit.
+			.AddSingleton<IHttpContentSerializer>(new SystemTextJsonContentSerializer(DefaultJsonSerializerOptions))
+			// Add the adapter for Nventive.Persistence.
 			.AddSingleton<ISettingsSerializer>(c => new JsonSerializerToSettingsSerializerAdapter(DefaultJsonSerializerOptions));
 
 		return services;


### PR DESCRIPTION
GitHub Issue: #

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [x] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## Description

<!-- (Please describe the changes that this PR introduces.) -->
- The Refit serializer now properly uses the `JsonSerializerOptions` that has code generated deserializers and serializers (the one that refers `JsonContext`).

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major**
  - The template structure was changed.
- [ ] **Minor**
  - New functionalities were added.
- [x] **Patch**
  - A bug in behavior was fixed.
  - Documentation was changed.

## PR Checklist 

### Always applicable
No matter your changes, these checks always apply.
- [x] Your conventional commits are aligned with the **Impact on version** section.
- [x] Updated [CHANGELOG.md](../blob/main/CHANGELOG.md).
  - Use the latest Major.Minor.X header if you do a **Patch** change.
  - Create a new Major.Minor.X header if you do a **Minor** or **Major** change.
  - If you create a new header, it aligns with the **Impact on version** section and matches what is generated in the build pipeline.
- [x] Documentation files were updated according with the changes.
  - Update `README.md` and `TemplateConfig.md` if you made changes to **templating**.
  - Update `AzurePipelines.md` and `APP_README.md` if you made changes to **pipelines**.
  - Update `Diagnostics.md` if you made changes to **diagnostic tools**.
  - Update `Architecture.md` and its diagrams if you made **architecture decisions** or if you introduced new **recipes**.
  - ...and so forth: Make sure you update the documentation files associated to the recipes you changed. Review the topics by looking at the content of the `doc/` folder.
- [x] Images about the template are referenced from the [wiki](https://github.com/nventive/UnoApplicationTemplate/wiki/Images) and added as images in this git.
- [x] TODO comments are hints for next steps for users of the template and not planned work.

### Contextual
Based on your changes these checks may not apply.
- [ ] Automated tests for the changes have been added/updated.
- [x] Tested on all relevant platforms

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->