### PR TITLE
doc: Updating configuration documentation and uno workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Prefix your items with `(Template)` if the change is about the template and not 
 - Renamed multiple components from the data access layer to not all be named `Repository`.
 - Moved many components from the presentation layer to the data access layer.
 - Disabled simulated API call delays in automated tests.
+- Updated Configuration documentation and uno workaround comment.
 
 ## 3.8.X
 - Updated from .NET 8 to .NET 9.

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -1,4 +1,4 @@
-# Configuration
+﻿# Configuration
 
 We use [Microsoft.Extensions.Hosting](https://www.nuget.org/packages/Microsoft.Extensions.Hosting) for any configuration related work.
 
@@ -14,7 +14,7 @@ The `IConfiguration` is populated using 3 layers of configuration files.
  
 1. `appsettings.override.json` is an optional file that appears when you override a value from the application.
 
-Check the `AddAppSettings` method from [AppSettingsConfiguration.cs](../src/app/ApplicationTemplate.Presentation/Configuration/AppSettingsConfiguration.cs) file to see how the 3 layers are setup.
+Check the `AddConfiguration` method from the [ConfigurationConfiguration.cs](../src/app/ParklandPriceSurvey.Presentation/Configuration/ConfigurationConfiguration.cs) file to see how the 3 layers are setup.
 
 ## Accessing
 

--- a/src/app/ApplicationTemplate.Shared.Views/Behaviors/CommandBarSafeAreaBehavior.cs
+++ b/src/app/ApplicationTemplate.Shared.Views/Behaviors/CommandBarSafeAreaBehavior.cs
@@ -20,6 +20,8 @@ public class CommandBarSafeAreaBehavior
 	{
 		if (d is CommandBar commandBar && (bool)e.NewValue)
 		{
+			// We can remove this workaround when uno.winui 5.7.0 is stable because they fixed it, as of right now it's in prerelease.
+			// It's also being backported to 5.6.0 which we are on right now but it's not backported as of now.
 #if ANDROID
 			commandBar.Loaded += (s, args) =>
 			{


### PR DESCRIPTION
GitHub Issue: #

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [ ] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [x] Documentation content changes
 - [ ] Other, please describe:

## Description

<!-- (Please describe the changes that this PR introduces.) -->

I'm updating the documentation for the ConfigurationConfiguration file because it was referencing AppSettingsConfiguration which was what we had before. Also updating the workaround for the uno commandbar safe area bug because the fix is coming in 5.7.0 or a backport in 5.6.0 which isn't happening yet.


## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major**
  - The template structure was changed.
- [ ] **Minor**
  - New functionalities were added.
- [x] **Patch**
  - A bug in behavior was fixed.
  - Documentation was changed.

## PR Checklist 

### Always applicable
No matter your changes, these checks always apply.
- [x] Your conventional commits are aligned with the **Impact on version** section.
- [x] Updated [CHANGELOG.md](../blob/main/CHANGELOG.md).
  - Use the latest Major.Minor.X header if you do a **Patch** change.
  - Create a new Major.Minor.X header if you do a **Minor** or **Major** change.
  - If you create a new header, it aligns with the **Impact on version** section and matches what is generated in the build pipeline.
- [x] Documentation files were updated according with the changes.
  - Update `README.md` and `TemplateConfig.md` if you made changes to **templating**.
  - Update `AzurePipelines.md` and `APP_README.md` if you made changes to **pipelines**.
  - Update `Diagnostics.md` if you made changes to **diagnostic tools**.
  - Update `Architecture.md` and its diagrams if you made **architecture decisions** or if you introduced new **recipes**.
  - ...and so forth: Make sure you update the documentation files associated to the recipes you changed. Review the topics by looking at the content of the `doc/` folder.
- [ ] Images about the template are referenced from the [wiki](https://github.com/nventive/UnoApplicationTemplate/wiki/Images) and added as images in this git.
- [ ] TODO comments are hints for next steps for users of the template and not planned work.

### Contextual
Based on your changes these checks may not apply.
- [ ] Automated tests for the changes have been added/updated.
- [ ] Tested on all relevant platforms

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->