### PR TITLE
fix: Add VM Disposal in Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Prefix your items with `(Template)` if the change is about the template and not 
 - Updated the Segoe MDL2 Assets font to fix an issue with the Flip View icons on Windows.
 - Optimized the .NET workloads install process.
 - Fixed the iOS application icon size.
+- Added VM Disposal in Functional Tests.
 
 ## 3.8.X
 - Updated from .NET 8 to .NET 9.

--- a/src/app/ApplicationTemplate.Presentation/ViewModels/Extensions/ISectionsNavigator.Extensions.cs
+++ b/src/app/ApplicationTemplate.Presentation/ViewModels/Extensions/ISectionsNavigator.Extensions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Threading.Tasks;
+using System.Threading;
 using Chinook.StackNavigation;
 
 namespace Chinook.SectionsNavigation;
@@ -51,4 +53,43 @@ public static class SectionsNavigatorExtensions
 				var state = args.EventArgs.CurrentState;
 				return state.ActiveSection.Name;
 			});
+
+	/// <summary>
+	/// Clears the sections and sets the active section to <paramref name="activeSectionName"/> if not null or empty.
+	/// </summary>
+	/// <param name="sectionsNavigator"><see cref="ISectionsNavigator"/>.</param>
+	/// <param name="ct">The cancellation token.</param>
+	/// <param name="activeSectionName">The active section name to set after clearing them all.</param>
+	/// <remarks>
+	/// There are good chances that the page requesting this operation gets disposed, so you should use <see cref="CancellationToken.None"/>.
+	/// <br/>
+	/// If you don't want any section set as active don't provide <paramref name="activeSectionName"/>.
+	/// </remarks>
+	public static async Task ClearSections(this ISectionsNavigator sectionsNavigator, CancellationToken ct, string activeSectionName = default)
+	{
+		// Clearing those pages prevents bindings from updating in background.
+		// For better performance, it's better to re-create the pages when we'll need them.
+		foreach (var section in sectionsNavigator.State.Sections.Values)
+		{
+			await section.Clear(ct);
+		}
+
+		if (!string.IsNullOrEmpty(activeSectionName))
+		{
+			await sectionsNavigator.SetActiveSection(ct, activeSectionName);
+		}
+	}
+
+	/// <summary>
+	/// Closes all modals.
+	/// </summary>
+	/// <param name="sectionsNavigator"><see cref="ISectionsNavigator"/>.</param>
+	/// <param name="ct">The cancellation token.</param>
+	public static async Task CloseModals(this ISectionsNavigator sectionsNavigator, CancellationToken ct)
+	{
+		foreach (var modal in sectionsNavigator.State.Modals)
+		{
+			await sectionsNavigator.CloseModal(ct, SectionsNavigatorRequest.GetCloseModalRequest(modalName: modal.Name));
+		}
+	}
 }

--- a/src/app/ApplicationTemplate.Tests.Functional/ForceUpdate/ForceUpdatesShould.cs
+++ b/src/app/ApplicationTemplate.Tests.Functional/ForceUpdate/ForceUpdatesShould.cs
@@ -2,8 +2,9 @@
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using ApplicationTemplate.DataAccess;
+using ApplicationTemplate.Tests;
 
-namespace ApplicationTemplate.Tests;
+namespace ForceUpdate;
 
 /// <summary>
 /// Tests for the forced update flow.

--- a/src/app/ApplicationTemplate.Tests.Functional/Posts/EditPostPageViewModelShould.cs
+++ b/src/app/ApplicationTemplate.Tests.Functional/Posts/EditPostPageViewModelShould.cs
@@ -2,9 +2,10 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using ApplicationTemplate.Tests;
 using Xunit.Abstractions;
 
-namespace ApplicationTemplate.Tests;
+namespace Posts;
 
 public sealed class EditPostPageViewModelShould : FunctionalTestBase
 {


### PR DESCRIPTION
GitHub Issue: #

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [x] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## Description

<!-- (Please describe the changes that this PR introduces.) -->

Make sure the view models are disposed of at the end of each functional test.


## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major**
  - The template structure was changed.
- [ ] **Minor**
  - New functionalities were added.
- [x] **Patch**
  - A bug in behavior was fixed.
  - Documentation was changed.

## PR Checklist 

### Always applicable
No matter your changes, these checks always apply.
- [x] Your conventional commits are aligned with the **Impact on version** section.
- [x] Updated [CHANGELOG.md](../blob/main/CHANGELOG.md).
  - Use the latest Major.Minor.X header if you do a **Patch** change.
  - Create a new Major.Minor.X header if you do a **Minor** or **Major** change.
  - If you create a new header, it aligns with the **Impact on version** section and matches what is generated in the build pipeline.
- [x] Documentation files were updated according with the changes.
  - Update `README.md` and `TemplateConfig.md` if you made changes to **templating**.
  - Update `AzurePipelines.md` and `APP_README.md` if you made changes to **pipelines**.
  - Update `Diagnostics.md` if you made changes to **diagnostic tools**.
  - Update `Architecture.md` and its diagrams if you made **architecture decisions** or if you introduced new **recipes**.
  - ...and so forth: Make sure you update the documentation files associated to the recipes you changed. Review the topics by looking at the content of the `doc/` folder.
- [x] Images about the template are referenced from the [wiki](https://github.com/nventive/UnoApplicationTemplate/wiki/Images) and added as images in this git.
- [x] TODO comments are hints for next steps for users of the template and not planned work.

### Contextual
Based on your changes these checks may not apply.
- [x] Automated tests for the changes have been added/updated.
- [ ] Tested on all relevant platforms

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->