### PR TITLE
fix: Adding workaround for language bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Prefix your items with `(Template)` if the change is about the template and not 
 ## 3.10.X
 - Added Dependency Injection validation in the development environment.
 - Cleaned up the persistence configuration files (removed unused parameters and updated documentation).
+- Adding a workaround for a bug with the language change on android.
 
 ## 3.9.X
 - Removed unnecessary `IsExternalInit.cs` files.

--- a/src/app/ApplicationTemplate.Shared.Views/Configuration/LocalizationConfiguration.cs
+++ b/src/app/ApplicationTemplate.Shared.Views/Configuration/LocalizationConfiguration.cs
@@ -75,7 +75,7 @@ public static class LocalizationConfiguration
 		var folderPath = string.Empty;
 //-:cnd:noEmit
 #endif
-//+:cnd:noEmit
+		//+:cnd:noEmit
 
 		return Path.Combine(folderPath, "culture-override");
 	}
@@ -170,7 +170,19 @@ public class ThreadCultureOverrideService : IThreadCultureOverrideService
 	{
 		try
 		{
+//-:cnd:noEmit
+#if ANDROID
+//+:cnd:noEmit
+			// We need a special case for Android because the CurrentCulture does not return the correct value after changing the device language.
+			var locale = Java.Util.Locale.Default; // Gets the real system language
+			var culture = new CultureInfo(locale.ToString());
+//-:cnd:noEmit
+#else
+//+:cnd:noEmit
 			var culture = CultureInfo.CurrentCulture;
+//-:cnd:noEmit
+#endif
+//+:cnd:noEmit
 
 			// Use the settings culture if it is set.
 			var settingsCulture = GetCulture();


### PR DESCRIPTION
GitHub Issue: #

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [x] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## Description

<!-- (Please describe the changes that this PR introduces.) -->
Since migrating from net 6 there's a bug where on android the current culture doesn't return the "current" culture but rather the one that was current when the app was installed so im adding the workaround we added on other projects

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major**
  - The template structure was changed.
- [ ] **Minor**
  - New functionalities were added.
- [x] **Patch**
  - A bug in behavior was fixed.
  - Documentation was changed.

## PR Checklist 

### Always applicable
No matter your changes, these checks always apply.
- [x] Your conventional commits are aligned with the **Impact on version** section.
- [x] Updated [CHANGELOG.md](../blob/main/CHANGELOG.md).
  - Use the latest Major.Minor.X header if you do a **Patch** change.
  - Create a new Major.Minor.X header if you do a **Minor** or **Major** change.
  - If you create a new header, it aligns with the **Impact on version** section and matches what is generated in the build pipeline.
- [x] Documentation files were updated according with the changes.
  - Update `README.md` and `TemplateConfig.md` if you made changes to **templating**.
  - Update `AzurePipelines.md` and `APP_README.md` if you made changes to **pipelines**.
  - Update `Diagnostics.md` if you made changes to **diagnostic tools**.
  - Update `Architecture.md` and its diagrams if you made **architecture decisions** or if you introduced new **recipes**.
  - ...and so forth: Make sure you update the documentation files associated to the recipes you changed. Review the topics by looking at the content of the `doc/` folder.
- [x] Images about the template are referenced from the [wiki](https://github.com/nventive/UnoApplicationTemplate/wiki/Images) and added as images in this git.
- [x] TODO comments are hints for next steps for users of the template and not planned work.

### Contextual
Based on your changes these checks may not apply.
- [ ] Automated tests for the changes have been added/updated.
- [x] Tested on all relevant platforms

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->