### PR TITLE
fix: Icon not showing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ Prefix your items with `(Template)` if the change is about the template and not 
 - Updated from .NET 9 to .NET 10.
 - Updated Android target SDK version to 36.
 - Updated android aot profile and profiling packages to 10.0.0-preview1.
-- Set MtouchUseLlvm to false for iOS release build to fix build time issue. 
+- Set MtouchUseLlvm to false for iOS release build to fix build time issue.
+- Changed the way that iOS app icons are added to the project.
 
 ## 3.11.X
 - Added API Client tests project.

--- a/src/app/ApplicationTemplate.Mobile/ApplicationTemplate.Mobile.csproj
+++ b/src/app/ApplicationTemplate.Mobile/ApplicationTemplate.Mobile.csproj
@@ -160,6 +160,7 @@
 				<CodesignEntitlements>iOS\Entitlements.plist</CodesignEntitlements>
 				<!-- Workaround for clang++ error on iOS simulator on ARM base macOS system. See "https://github.com/dotnet/maui/issues/16778#issuecomment-1683343255" for more detail. -->
 				<ForceSimulatorX64ArchitectureInIDE>true</ForceSimulatorX64ArchitectureInIDE>
+				<AppIcon>AppIcons</AppIcon>
 			</PropertyGroup>
 			<Choose>
 				<When Condition="'$(Configuration)'=='Debug'">

--- a/src/app/ApplicationTemplate.Mobile/iOS/Info.plist
+++ b/src/app/ApplicationTemplate.Mobile/iOS/Info.plist
@@ -42,8 +42,6 @@
 		</array>
 		<key>UIViewControllerBasedStatusBarAppearance</key>
 		<false/>
-		<key>XSAppIconAssets</key>
-		<string>Media.xcassets/AppIcons.appiconset</string>
 		<key>UIApplicationSupportsIndirectInputEvents</key>
 		<true/>
 		<!-- This is required to access the MAUI Essentials email functionality. -->


### PR DESCRIPTION
GitHub Issue: #

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [X] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## Description

<!-- (Please describe the changes that this PR introduces.) -->
Removed the XSAppIconAssets from info.plist and added <AppIcon>AppIcons</AppIcon> in the properties for IOS builds as XSAppIconAssets  doesnt seem to work with xcode26+.

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major**
  - The template structure was changed.
- [ ] **Minor**
  - New functionalities were added.
- [X] **Patch**
  - A bug in behavior was fixed.
  - Documentation was changed.

## PR Checklist 

### Always applicable
No matter your changes, these checks always apply.
- [x] Your conventional commits are aligned with the **Impact on version** section.
- [x] Updated [CHANGELOG.md](../blob/main/CHANGELOG.md).
  - Use the latest Major.Minor.X header if you do a **Patch** change.
  - Create a new Major.Minor.X header if you do a **Minor** or **Major** change.
  - If you create a new header, it aligns with the **Impact on version** section and matches what is generated in the build pipeline.
- [ ] Documentation files were updated according with the changes.
  - Update `README.md` and `TemplateConfig.md` if you made changes to **templating**.
  - Update `AzurePipelines.md` and `APP_README.md` if you made changes to **pipelines**.
  - Update `Diagnostics.md` if you made changes to **diagnostic tools**.
  - Update `Architecture.md` and its diagrams if you made **architecture decisions** or if you introduced new **recipes**.
  - ...and so forth: Make sure you update the documentation files associated to the recipes you changed. Review the topics by looking at the content of the `doc/` folder.
- [ ] Images about the template are referenced from the [wiki](https://github.com/nventive/UnoApplicationTemplate/wiki/Images) and added as images in this git.
- [ ] TODO comments are hints for next steps for users of the template and not planned work.

### Contextual
Based on your changes these checks may not apply.
- [ ] Automated tests for the changes have been added/updated.
- [x] Tested on all relevant platforms

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->